### PR TITLE
Sweep PNGs from the `res` directory to the `microfilm` directory

### DIFF
--- a/plugin/src/main/kotlin/app/cash/microfilm/CompressTask.kt
+++ b/plugin/src/main/kotlin/app/cash/microfilm/CompressTask.kt
@@ -1,11 +1,54 @@
 package app.cash.microfilm
 
+import java.io.File
 import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
 
+@DisableCachingByDefault(because = "This task modifies the source tree in place")
 abstract class CompressTask : DefaultTask() {
+  @get:Internal abstract val microfilmDirectory: DirectoryProperty
+
+  @get:Internal abstract val resourcesDirectory: DirectoryProperty
+
   @TaskAction
   fun compress() {
-    // TODO
+    // Find the resource PNGs
+    val resourcesDirectoryFile = resourcesDirectory.get().asFile
+    val resourcesPngs =
+      resourcesDirectoryFile
+        .walk()
+        .filter { it.isFile && it.extension.equals("png", ignoreCase = true) }
+        .filter { !it.name.endsWith(".9.png", ignoreCase = true) }
+        .filter { it.isInDrawableDirectory() }
+        .toList()
+
+    // Sweep the resource PNGs to the microfilm directory
+    val microfilmDirectoryFile = microfilmDirectory.get().asFile
+    resourcesPngs.forEach { resourcesPng ->
+      val microfilmPng =
+        File(
+          microfilmDirectoryFile,
+          resourcesPng
+            .relativeTo(base = resourcesDirectoryFile)
+            .path
+            .replace(oldChar = '\\', newChar = '/'),
+        )
+      microfilmPng.parentFile?.mkdirs()
+      resourcesPng.copyTo(target = microfilmPng, overwrite = true)
+      resourcesPng.delete()
+    }
+
+    // TODO: compress the PNGs to WebP
+  }
+
+  companion object {
+    private val DRAWABLE_DIRECTORY_PATTERN = Regex("^drawable(-.*)?$")
+
+    private fun File.isInDrawableDirectory(): Boolean {
+      return parentFile?.name?.let { DRAWABLE_DIRECTORY_PATTERN.matches(it) } == true
+    }
   }
 }

--- a/plugin/src/main/kotlin/app/cash/microfilm/MicrofilmPlugin.kt
+++ b/plugin/src/main/kotlin/app/cash/microfilm/MicrofilmPlugin.kt
@@ -46,6 +46,8 @@ class MicrofilmPlugin : Plugin<Project> {
         tasks.register("compressMicrofilm$nameCapitalized", CompressTask::class.java) { task ->
           task.description = "Compresses source images for the '$name' source set"
           task.group = "microfilm"
+          task.microfilmDirectory.set(layout.projectDirectory.dir("src/$name/microfilm"))
+          task.resourcesDirectory.set(layout.projectDirectory.dir("src/$name/res"))
         }
       val verifySourceSet =
         tasks.register("verifyMicrofilm$nameCapitalized", VerifyTask::class.java) { task ->


### PR DESCRIPTION
The first step of the compress task is to sweep the PNGs from the `res` directory to a separate directory that won't be included when the app is built. Later in the stack we'll implement the actual compression.

Right now I'm calling this directory `microfilm` and I'm placing it alongside the other `src` directories so that the final output looks something like this:
```
src/main/
├── kotlin/
├── microfilm/
│   ├── manifest.json
│   └── drawable-hdpi/
│       └── icon.png
└── res/
    └── drawable-hdpi/
        └── icon.webp
```

I'm not sure this is the best name/location for the directory though. Let me know if you have other ideas!