### PR TITLE
Mark `VerifyTask` as cacheable

### DIFF
--- a/plugin/src/main/kotlin/app/cash/microfilm/VerifyTask.kt
+++ b/plugin/src/main/kotlin/app/cash/microfilm/VerifyTask.kt
@@ -1,8 +1,10 @@
 package app.cash.microfilm
 
 import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.TaskAction
 
+@CacheableTask
 abstract class VerifyTask : DefaultTask() {
   @TaskAction
   fun verify() {


### PR DESCRIPTION
With the `testkit` plugin added, the `check` task is [failing on CI](https://github.com/block/microfilm/actions/runs/24542520937/job/71751212361?pr=10) because `VerifyTask` doesn't have an annotation indicating whether it's cacheable or not:
```
Execution failed for task ':plugin:validatePlugins'.
> Plugin validation failed with 1 problem:
    - Error: Type 'app.cash.microfilm.VerifyTask' must be annotated either with @CacheableTask or with @DisableCachingByDefault.
      
      Reason: The task author should make clear why a task is not cacheable.
      
      Possible solutions:
        1. Add @DisableCachingByDefault(because = ...).
        2. Add @CacheableTask.
        3. Add @UntrackedTask(because = ...).
      
      For more information, please refer to https://docs.gradle.org/9.4.1/userguide/validation_problems.html#disable_caching_by_default in the Gradle documentation.
  For more on how to annotate task properties, please refer to https://docs.gradle.org/9.4.1/userguide/incremental_build.html#sec:task_input_output_annotations in the Gradle documentation.
```

I'm marking it as cacheable for now.