### PR TITLE
Implement compression to WebP

### DIFF
--- a/plugin/src/main/kotlin/app/cash/microfilm/CompressTask.kt
+++ b/plugin/src/main/kotlin/app/cash/microfilm/CompressTask.kt
@@ -1,17 +1,34 @@
 package app.cash.microfilm
 
 import java.io.File
+import javax.inject.Inject
+import kotlin.text.RegexOption.IGNORE_CASE
 import org.gradle.api.DefaultTask
+import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity.RELATIVE
 import org.gradle.api.tasks.TaskAction
+import org.gradle.process.ExecOperations
 import org.gradle.work.DisableCachingByDefault
 
 @DisableCachingByDefault(because = "This task modifies the source tree in place")
-abstract class CompressTask : DefaultTask() {
+abstract class CompressTask @Inject constructor(private val execOperations: ExecOperations) :
+  DefaultTask() {
+  @get:InputFiles
+  @get:PathSensitive(RELATIVE)
+  abstract val cwebpDirectory: ConfigurableFileCollection
+
   @get:Internal abstract val microfilmDirectory: DirectoryProperty
 
   @get:Internal abstract val resourcesDirectory: DirectoryProperty
+
+  @get:Internal abstract val lossless: Property<Boolean>
+
+  @get:Internal abstract val quality: Property<Int>
 
   @TaskAction
   fun compress() {
@@ -41,11 +58,47 @@ abstract class CompressTask : DefaultTask() {
       resourcesPng.delete()
     }
 
-    // TODO: compress the PNGs to WebP
+    // Compress the PNGs to WebP in the resources directory
+    val cwebpExecutable = cwebpDirectory.singleFile.resolve("cwebp")
+    microfilmDirectoryFile
+      .walk()
+      .filter { it.isFile && it.extension.equals("png", ignoreCase = true) }
+      .toList()
+      .forEach { microfilmPng ->
+        val resourcesWebp =
+          File(
+            resourcesDirectoryFile,
+            microfilmPng
+              .relativeTo(base = microfilmDirectoryFile)
+              .path
+              .replace(oldChar = '\\', newChar = '/')
+              .replace(PNG_EXTENSION_PATTERN, ".webp"),
+          )
+        resourcesWebp.parentFile?.mkdirs()
+        execOperations.exec { action ->
+          action.commandLine(
+            buildList {
+              add(cwebpExecutable.absolutePath)
+              add("-metadata")
+              add("icc")
+              if (lossless.get()) {
+                add("-lossless")
+              } else {
+                add("-q")
+                add(quality.get().toString())
+              }
+              add("-o")
+              add(resourcesWebp.absolutePath)
+              add(microfilmPng.absolutePath)
+            }
+          )
+        }
+      }
   }
 
   companion object {
-    private val DRAWABLE_DIRECTORY_PATTERN = Regex("^drawable(-.*)?$")
+    private val DRAWABLE_DIRECTORY_PATTERN = Regex(pattern = "^drawable(-.*)?$")
+    private val PNG_EXTENSION_PATTERN = Regex(pattern = "\\.png$", option = IGNORE_CASE)
 
     private fun File.isInDrawableDirectory(): Boolean {
       return parentFile?.name?.let { DRAWABLE_DIRECTORY_PATTERN.matches(it) } == true

--- a/plugin/src/main/kotlin/app/cash/microfilm/MicrofilmPlugin.kt
+++ b/plugin/src/main/kotlin/app/cash/microfilm/MicrofilmPlugin.kt
@@ -5,6 +5,7 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.type.ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE
 import org.gradle.api.artifacts.type.ArtifactTypeDefinition.JAR_TYPE
+import org.gradle.api.file.FileCollection
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.nativeplatform.MachineArchitecture
 import org.gradle.nativeplatform.MachineArchitecture.ARCHITECTURE_ATTRIBUTE
@@ -69,17 +70,32 @@ class MicrofilmPlugin : Plugin<Project> {
 
     // Configure the tasks to run for each source set
     plugins.withId("com.android.application") {
-      configureSourceSets(compress = compress, verify = verify)
+      configureSourceSets(
+        extension = extension,
+        cwebpDirectory = cwebpDirectory,
+        compress = compress,
+        verify = verify,
+      )
     }
     plugins.withId("com.android.library") {
-      configureSourceSets(compress = compress, verify = verify)
+      configureSourceSets(
+        extension = extension,
+        cwebpDirectory = cwebpDirectory,
+        compress = compress,
+        verify = verify,
+      )
     }
 
     // Link the verify task to the common check task
     plugins.withId("base") { tasks.named("check").configure { it.dependsOn(verify) } }
   }
 
-  private fun Project.configureSourceSets(compress: TaskProvider<*>, verify: TaskProvider<*>) {
+  private fun Project.configureSourceSets(
+    extension: MicrofilmExtension,
+    cwebpDirectory: FileCollection,
+    compress: TaskProvider<*>,
+    verify: TaskProvider<*>,
+  ) {
     extensions.getByType(CommonExtension::class.java).sourceSets.configureEach { sourceSet ->
       val name = sourceSet.name
       val nameCapitalized = name.replaceFirstChar { it.uppercase() }
@@ -89,8 +105,12 @@ class MicrofilmPlugin : Plugin<Project> {
         tasks.register("compressMicrofilm$nameCapitalized", CompressTask::class.java) { task ->
           task.description = "Compresses source images for the '$name' source set"
           task.group = "microfilm"
+          task.cwebpDirectory.from(cwebpDirectory)
           task.microfilmDirectory.set(layout.projectDirectory.dir("src/$name/microfilm"))
           task.resourcesDirectory.set(layout.projectDirectory.dir("src/$name/res"))
+          task.lossless.set(extension.lossless)
+          task.quality.set(extension.quality)
+          task.outputs.upToDateWhen { false }
         }
       val verifySourceSet =
         tasks.register("verifyMicrofilm$nameCapitalized", VerifyTask::class.java) { task ->


### PR DESCRIPTION
Uses the platform-specific `cwebp` dependency from the previous PR to actually compress the images to WebP after they've been swept into the microfilm directory.