### PR TITLE
Write the manifest after compressing the images

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ composeUi = "androidx.compose.ui:ui:1.10.6"
 junit-bom = "org.junit:junit-bom:5.12.2"
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter" }
 junit-launcher = { module = "org.junit.platform:junit-platform-launcher" }
+kotlinx-serialization-json = "org.jetbrains.kotlinx:kotlinx-serialization-json:1.11.0"
 ktfmt = "com.facebook:ktfmt:0.62"
 truth = "com.google.truth:truth:1.4.4"
 
@@ -21,5 +22,6 @@ androidLibrary = { id = "com.android.library", version.ref = "agp" }
 buildconfig = { id = "com.github.gmazzo.buildconfig", version = "6.0.9" }
 kotlinCompose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlinJvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 spotless = { id = "com.diffplug.spotless", version = "8.4.0" }
 testkit = { id = "com.autonomousapps.testkit", version.ref = "testkit" }

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
   `java-gradle-plugin`
   alias(libs.plugins.kotlinJvm)
+  alias(libs.plugins.kotlinSerialization)
   alias(libs.plugins.testkit)
   alias(libs.plugins.buildconfig)
 }
@@ -28,6 +29,8 @@ tasks.withType<Test>().configureEach {
 
 dependencies {
   compileOnly(libs.agp)
+
+  implementation(libs.kotlinx.serialization.json)
 
   functionalTestImplementation(platform(libs.junit.bom))
   functionalTestImplementation(libs.junit.jupiter)

--- a/plugin/src/main/kotlin/app/cash/microfilm/CompressTask.kt
+++ b/plugin/src/main/kotlin/app/cash/microfilm/CompressTask.kt
@@ -1,8 +1,11 @@
 package app.cash.microfilm
 
+import java.io.ByteArrayOutputStream
 import java.io.File
 import javax.inject.Inject
 import kotlin.text.RegexOption.IGNORE_CASE
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.json.Json
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
@@ -30,10 +33,13 @@ abstract class CompressTask @Inject constructor(private val execOperations: Exec
 
   @get:Internal abstract val quality: Property<Int>
 
+  private val microfilmDirectoryFile by lazy { microfilmDirectory.get().asFile }
+  private val microfilmManifestFile by lazy { File(microfilmDirectoryFile, "manifest.json") }
+  private val resourcesDirectoryFile by lazy { resourcesDirectory.get().asFile }
+
   @TaskAction
   fun compress() {
-    // Find the resource PNGs
-    val resourcesDirectoryFile = resourcesDirectory.get().asFile
+    // Find the resources PNGs
     val resourcesPngs =
       resourcesDirectoryFile
         .walk()
@@ -42,63 +48,115 @@ abstract class CompressTask @Inject constructor(private val execOperations: Exec
         .filter { it.isInDrawableDirectory() }
         .toList()
 
-    // Sweep the resource PNGs to the microfilm directory
-    val microfilmDirectoryFile = microfilmDirectory.get().asFile
+    // Sweep the resources PNGs to the microfilm directory
     resourcesPngs.forEach { resourcesPng ->
-      val microfilmPng =
-        File(
-          microfilmDirectoryFile,
-          resourcesPng
-            .relativeTo(base = resourcesDirectoryFile)
-            .path
-            .replace(oldChar = '\\', newChar = '/'),
-        )
+      val microfilmPng = resourcesPngToMicrofilmPng(resourcesPng = resourcesPng)
       microfilmPng.parentFile?.mkdirs()
       resourcesPng.copyTo(target = microfilmPng, overwrite = true)
       resourcesPng.delete()
     }
 
-    // Compress the PNGs to WebP in the resources directory
+    // Find the microfilm PNGs
+    val microfilmPngs =
+      microfilmDirectoryFile
+        .walk()
+        .filter { it.isFile && it.extension.equals("png", ignoreCase = true) }
+        .toList()
+
+    // Compress the microfilm PNGs to WebP in the resources directory
     val cwebpExecutable = cwebpDirectory.singleFile.resolve("cwebp")
-    microfilmDirectoryFile
-      .walk()
-      .filter { it.isFile && it.extension.equals("png", ignoreCase = true) }
-      .toList()
-      .forEach { microfilmPng ->
-        val resourcesWebp =
-          File(
-            resourcesDirectoryFile,
-            microfilmPng
-              .relativeTo(base = microfilmDirectoryFile)
-              .path
-              .replace(oldChar = '\\', newChar = '/')
-              .replace(PNG_EXTENSION_PATTERN, ".webp"),
-          )
-        resourcesWebp.parentFile?.mkdirs()
-        execOperations.exec { action ->
-          action.commandLine(
-            buildList {
-              add(cwebpExecutable.absolutePath)
-              add("-metadata")
-              add("icc")
-              if (lossless.get()) {
-                add("-lossless")
-              } else {
-                add("-q")
-                add(quality.get().toString())
-              }
-              add("-o")
-              add(resourcesWebp.absolutePath)
-              add(microfilmPng.absolutePath)
+    microfilmPngs.forEach { microfilmPng ->
+      val resourcesWebp = microfilmPngToResourcesWebp(microfilmPng = microfilmPng)
+      resourcesWebp.parentFile?.mkdirs()
+      execOperations.exec { action ->
+        action.commandLine(
+          buildList {
+            add(cwebpExecutable.absolutePath)
+            add("-metadata")
+            add("icc")
+            if (lossless.get()) {
+              add("-lossless")
+            } else {
+              add("-q")
+              add(quality.get().toString())
             }
-          )
-        }
+            add("-o")
+            add(resourcesWebp.absolutePath)
+            add(microfilmPng.absolutePath)
+          }
+        )
       }
+    }
+
+    // Get the current cwebp version
+    val output = ByteArrayOutputStream()
+    execOperations.exec { action ->
+      action.commandLine(cwebpExecutable.absolutePath, "-version")
+      action.standardOutput = output
+    }
+    val cwebpVersion = output.toString().lines().first().trim()
+
+    // Create the manifest
+    val manifest =
+      Manifest(
+        entries =
+          microfilmPngs
+            .sortedBy { it.invariantSeparatorsPath }
+            .map { microfilmPng ->
+              val resourcesWebp = microfilmPngToResourcesWebp(microfilmPng = microfilmPng)
+              Manifest.Entry(
+                sourcePath =
+                  microfilmPng.relativeTo(base = microfilmDirectoryFile).invariantSeparatorsPath,
+                sourceSha256 = microfilmPng.sha256(),
+                compressedPath =
+                  resourcesWebp.relativeTo(base = resourcesDirectoryFile).invariantSeparatorsPath,
+                compressedSha256 = resourcesWebp.sha256(),
+                compressor =
+                  Manifest.Compressor(
+                    name = "cwebp",
+                    version = cwebpVersion,
+                    lossless = lossless.get(),
+                    quality = quality.get(),
+                  ),
+              )
+            }
+      )
+
+    // Write the manifest to disk
+    if (manifest.entries.isEmpty()) {
+      microfilmManifestFile.delete()
+    } else {
+      microfilmManifestFile.writeText(
+        text = JSON.encodeToString(serializer = Manifest.serializer(), value = manifest) + "\n"
+      )
+    }
   }
+
+  private fun resourcesPngToMicrofilmPng(resourcesPng: File) =
+    File(
+      microfilmDirectoryFile,
+      resourcesPng.relativeTo(base = resourcesDirectoryFile).invariantSeparatorsPath,
+    )
+
+  private fun microfilmPngToResourcesWebp(microfilmPng: File) =
+    File(
+      resourcesDirectoryFile,
+      microfilmPng
+        .relativeTo(base = microfilmDirectoryFile)
+        .invariantSeparatorsPath
+        .replace(PNG_EXTENSION_PATTERN, ".webp"),
+    )
 
   companion object {
     private val DRAWABLE_DIRECTORY_PATTERN = Regex(pattern = "^drawable(-.*)?$")
     private val PNG_EXTENSION_PATTERN = Regex(pattern = "\\.png$", option = IGNORE_CASE)
+
+    @OptIn(ExperimentalSerializationApi::class)
+    private val JSON = Json {
+      encodeDefaults = true
+      prettyPrint = true
+      prettyPrintIndent = "  "
+    }
 
     private fun File.isInDrawableDirectory(): Boolean {
       return parentFile?.name?.let { DRAWABLE_DIRECTORY_PATTERN.matches(it) } == true

--- a/plugin/src/main/kotlin/app/cash/microfilm/Files.kt
+++ b/plugin/src/main/kotlin/app/cash/microfilm/Files.kt
@@ -1,0 +1,17 @@
+package app.cash.microfilm
+
+import java.io.File
+import java.security.MessageDigest
+
+/** Produces the SHA256 hash of the given file. */
+fun File.sha256(): String {
+  val digest = MessageDigest.getInstance("SHA-256")
+  inputStream().use { input ->
+    val buffer = ByteArray(8192)
+    var bytesRead: Int
+    while (input.read(buffer).also { bytesRead = it } != -1) {
+      digest.update(buffer, 0, bytesRead)
+    }
+  }
+  return digest.digest().joinToString("") { "%02x".format(it) }
+}

--- a/plugin/src/main/kotlin/app/cash/microfilm/Manifest.kt
+++ b/plugin/src/main/kotlin/app/cash/microfilm/Manifest.kt
@@ -1,0 +1,23 @@
+package app.cash.microfilm
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Manifest(val entries: List<Entry> = emptyList()) {
+  @Serializable
+  data class Entry(
+    val sourcePath: String,
+    val sourceSha256: String,
+    val compressedPath: String,
+    val compressedSha256: String,
+    val compressor: Compressor,
+  )
+
+  @Serializable
+  data class Compressor(
+    val name: String,
+    val version: String,
+    val lossless: Boolean,
+    val quality: Int?,
+  )
+}


### PR DESCRIPTION
After we've swept the resources PNGs into the microfilm directory, and compressed them back to WebP in the resources directory, we need to write the manifest so that it reflects the current state of the world.

> [!NOTE]
> I recommend hiding whitespace in the commit — the indentation of the compression stuff changed but the logic is still the same.