### PR TITLE
Fix Spotless to run on all build scripts

### DIFF
--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -7,11 +7,7 @@ pluginManagement {
 
 @Suppress("UnstableApiUsage")
 dependencyResolutionManagement {
-  versionCatalogs {
-    create("libs") {
-      from(files("../gradle/libs.versions.toml"))
-    }
-  }
+  versionCatalogs { create("libs") { from(files("../gradle/libs.versions.toml")) } }
 
   repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
   repositories {
@@ -21,5 +17,7 @@ dependencyResolutionManagement {
 }
 
 rootProject.name = "build-logic"
+
 include(":plugin")
+
 project(":plugin").projectDir = File("../plugin")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,10 @@ configure<SpotlessExtension> {
     target("**/src/**/*.kt")
     ktfmt(libs.ktfmt.get().version).googleStyle()
   }
-  kotlinGradle { ktfmt(libs.ktfmt.get().version).googleStyle() }
+  kotlinGradle {
+    target("**/*.gradle.kts")
+    ktfmt(libs.ktfmt.get().version).googleStyle()
+  }
 }
 
 subprojects { version = extra["VERSION_NAME"]!! }

--- a/cwebp/build.gradle.kts
+++ b/cwebp/build.gradle.kts
@@ -49,7 +49,7 @@ enum class CwebpPlatform(
     architecture = X86_64,
     archivePlatform = "linux-x86-64",
     sha256 = "1c5ffab71efecefa0e3c23516c3a3a1dccb45cc310ae1095c6f14ae268e38067",
-  )
+  ),
 }
 
 val CwebpPlatform.archiveName
@@ -88,9 +88,7 @@ fun TaskContainer.registerDownloadTask(platform: CwebpPlatform): TaskProvider<Ta
       val url = URI(platform.downloadUrl).toURL()
       logger.lifecycle("Downloading ${platform.archiveName}...")
       url.openStream().use { inputStream ->
-        archiveFile.outputStream().use { outputStream ->
-          inputStream.copyTo(outputStream)
-        }
+        archiveFile.outputStream().use { outputStream -> inputStream.copyTo(outputStream) }
       }
 
       // Verify the archive file SHA
@@ -103,7 +101,8 @@ fun TaskContainer.registerDownloadTask(platform: CwebpPlatform): TaskProvider<Ta
           |  expected: ${platform.sha256}
           |  actual:   $sha256
           |The download may be corrupt or tampered with.
-          """.trimMargin()
+          """
+            .trimMargin()
         )
       }
     }
@@ -165,48 +164,44 @@ fun TaskContainer.registerJarTask(
     archiveClassifier.set(platform.name)
   }
 
-val cwebpBinaryConfiguration = configurations.create("cwebpBinary") {
-  isCanBeConsumed = true
-  isCanBeResolved = false
+val cwebpBinaryConfiguration =
+  configurations.create("cwebpBinary") {
+    isCanBeConsumed = true
+    isCanBeResolved = false
 
-  attributes {
-    attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.NATIVE_RUNTIME))
-  }
+    attributes { attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.NATIVE_RUNTIME)) }
 
-  CwebpPlatform.entries.forEach { platform ->
-    val variant = outgoing.variants.create(platform.toString()) {
-      attributes {
-        attribute(
-          OPERATING_SYSTEM_ATTRIBUTE,
-          objects.named(OperatingSystemFamily::class.java, platform.osFamily),
-        )
-        attribute(
-          ARCHITECTURE_ATTRIBUTE,
-          objects.named(MachineArchitecture::class.java, platform.architecture),
-        )
-      }
+    CwebpPlatform.entries.forEach { platform ->
+      val variant =
+        outgoing.variants.create(platform.toString()) {
+          attributes {
+            attribute(
+              OPERATING_SYSTEM_ATTRIBUTE,
+              objects.named(OperatingSystemFamily::class.java, platform.osFamily),
+            )
+            attribute(
+              ARCHITECTURE_ATTRIBUTE,
+              objects.named(MachineArchitecture::class.java, platform.architecture),
+            )
+          }
+        }
+
+      val download = tasks.registerDownloadTask(platform = platform)
+      val extract = tasks.registerExtractTask(platform = platform, download = download)
+      val jar = tasks.registerJarTask(platform = platform, extract = extract)
+
+      variant.artifact(jar)
     }
-
-    val download = tasks.registerDownloadTask(platform = platform)
-    val extract = tasks.registerExtractTask(platform = platform, download = download)
-    val jar = tasks.registerJarTask(platform = platform, extract = extract)
-
-    variant.artifact(jar)
   }
-}
 
-val softwareComponentFactory = extensions.getByType(PublishingExtension::class).softwareComponentFactory
+val softwareComponentFactory =
+  extensions.getByType(PublishingExtension::class).softwareComponentFactory
 val cwebpComponent = softwareComponentFactory.adhoc("cwebpComponent")
+
 components.add(cwebpComponent)
 
-cwebpComponent.addVariantsFromConfiguration(cwebpBinaryConfiguration) {
-  mapToMavenScope("runtime")
-}
+cwebpComponent.addVariantsFromConfiguration(cwebpBinaryConfiguration) { mapToMavenScope("runtime") }
 
 publishing {
-  publications {
-    create<MavenPublication>("maven") {
-      from(components["cwebpComponent"])
-    }
-  }
+  publications { create<MavenPublication>("maven") { from(components["cwebpComponent"]) } }
 }

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -38,9 +38,7 @@ dependencies {
 }
 
 buildConfig {
-  useKotlinOutput {
-    internalVisibility = true
-  }
+  useKotlinOutput { internalVisibility = true }
 
   packageName("app.cash.microfilm")
   buildConfigField("String", "microfilmVersion", "\"${project.version}\"")

--- a/sample/library/build.gradle.kts
+++ b/sample/library/build.gradle.kts
@@ -6,7 +6,5 @@ plugins {
 android {
   namespace = "app.cash.microfilm.sample.library"
   compileSdk = 36
-  defaultConfig {
-    minSdk = 24
-  }
+  defaultConfig { minSdk = 24 }
 }


### PR DESCRIPTION
I noticed that Spotless isn't covering all of our buildscripts. I'm fixing it so that the targeting matches what we do for Kotlin files.