### PR TITLE
Use a single configuration for cwebp binaries

### DIFF
--- a/cwebp/build.gradle.kts
+++ b/cwebp/build.gradle.kts
@@ -160,25 +160,28 @@ fun TaskContainer.registerJarTask(
     archiveClassifier.set(platform.name)
   }
 
-CwebpPlatform.entries.forEach { platform ->
-  val download = tasks.registerDownloadTask(platform = platform)
-  val extract = tasks.registerExtractTask(platform = platform, download = download)
-  val jar = tasks.registerJarTask(platform = platform, extract = extract)
+configurations.create("cwebpBinary") {
+  isCanBeConsumed = true
+  isCanBeResolved = false
 
-  // Create a configuration with OS and Architecture attributes for variant-aware resolution.
-  configurations.create("cwebpBinary$platform") {
-    isCanBeConsumed = true
-    isCanBeResolved = false
-    attributes {
-      attribute(
-        OPERATING_SYSTEM_ATTRIBUTE,
-        objects.named(OperatingSystemFamily::class.java, platform.osFamily),
-      )
-      attribute(
-        ARCHITECTURE_ATTRIBUTE,
-        objects.named(MachineArchitecture::class.java, platform.architecture),
-      )
+  CwebpPlatform.entries.forEach { platform ->
+    val variant = outgoing.variants.create(platform.toString()) {
+      attributes {
+        attribute(
+          OPERATING_SYSTEM_ATTRIBUTE,
+          objects.named(OperatingSystemFamily::class.java, platform.osFamily),
+        )
+        attribute(
+          ARCHITECTURE_ATTRIBUTE,
+          objects.named(MachineArchitecture::class.java, platform.architecture),
+        )
+      }
     }
-    outgoing.artifact(jar)
+
+    val download = tasks.registerDownloadTask(platform = platform)
+    val extract = tasks.registerExtractTask(platform = platform, download = download)
+    val jar = tasks.registerJarTask(platform = platform, extract = extract)
+
+    variant.artifact(jar)
   }
 }


### PR DESCRIPTION
Use secondary variants for the OS/Arch variants. This will simplify publishing later.

Output of `:cwebp:outgoingVariants`:

```
--------------------------------------------------
Variant cwebpBinary
--------------------------------------------------

Capabilities
    - microfilm:cwebp:0.1.0-SNAPSHOT (default capability)

Secondary Variants (*)

    --------------------------------------------------
    Secondary Variant LinuxArm64 (i)
    --------------------------------------------------
    
    Attributes
        - org.gradle.native.architecture    = aarch64
        - org.gradle.native.operatingSystem = linux
    Artifacts
        - build/distributions/cwebp-0.1.0-SNAPSHOT-LinuxArm64.jar (artifactType = jar, classifier = LinuxArm64)

    --------------------------------------------------
    Secondary Variant LinuxX86_64
    --------------------------------------------------
    
    Attributes
        - org.gradle.native.architecture    = x86-64
        - org.gradle.native.operatingSystem = linux
    Artifacts
        - build/distributions/cwebp-0.1.0-SNAPSHOT-LinuxX86_64.jar (artifactType = jar, classifier = LinuxX86_64)

    --------------------------------------------------
    Secondary Variant MacosArm64 (i)
    --------------------------------------------------
    
    Attributes
        - org.gradle.native.architecture    = aarch64
        - org.gradle.native.operatingSystem = macos
    Artifacts
        - build/distributions/cwebp-0.1.0-SNAPSHOT-MacosArm64.jar (artifactType = jar, classifier = MacosArm64)

    --------------------------------------------------
    Secondary Variant MacosX86_64
    --------------------------------------------------
    
    Attributes
        - org.gradle.native.architecture    = x86-64
        - org.gradle.native.operatingSystem = macos
    Artifacts
        - build/distributions/cwebp-0.1.0-SNAPSHOT-MacosX86_64.jar (artifactType = jar, classifier = MacosX86_64)
```