### PR TITLE
Switch from the Cash open source package to the Block one

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 import com.diffplug.gradle.spotless.SpotlessExtension
 
-buildscript { dependencies { classpath("app.cash.microfilm:plugin") } }
+buildscript { dependencies { classpath("xyz.block.microfilm:plugin") } }
 
 plugins {
   alias(libs.plugins.androidApplication) apply false

--- a/cwebp/build.gradle.kts
+++ b/cwebp/build.gradle.kts
@@ -18,7 +18,7 @@ plugins {
   alias(libs.plugins.testkit)
 }
 
-group = "app.cash.microfilm"
+group = "xyz.block.microfilm"
 
 enum class CwebpPlatform(
   val osFamily: String,

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-GROUP=app.cash.microfilm
+GROUP=xyz.block.microfilm
 VERSION_NAME=0.1.0-SNAPSHOT
 
 kotlin.code.style=official

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -9,8 +9,8 @@ plugins {
 gradlePlugin {
   plugins {
     create("microfilm") {
-      id = "app.cash.microfilm"
-      implementationClass = "app.cash.microfilm.MicrofilmPlugin"
+      id = "xyz.block.microfilm"
+      implementationClass = "xyz.block.microfilm.MicrofilmPlugin"
     }
   }
 }
@@ -40,6 +40,6 @@ dependencies {
 buildConfig {
   useKotlinOutput { internalVisibility = true }
 
-  packageName("app.cash.microfilm")
+  packageName("xyz.block.microfilm")
   buildConfigField("String", "microfilmVersion", "\"${project.version}\"")
 }

--- a/plugin/src/functionalTest/kotlin/xyz/block/microfilm/MicrofilmPluginFunctionalTest.kt
+++ b/plugin/src/functionalTest/kotlin/xyz/block/microfilm/MicrofilmPluginFunctionalTest.kt
@@ -1,4 +1,4 @@
-package app.cash.microfilm
+package xyz.block.microfilm
 
 import com.autonomousapps.kit.AbstractGradleProject
 import com.autonomousapps.kit.GradleBuilder
@@ -15,7 +15,7 @@ class MicrofilmPluginFunctionalTest {
   private val androidAppPlugin = Plugin("com.android.application", agpVersion)
   private val androidLibPlugin = Plugin("com.android.library", agpVersion)
   private val microfilmPlugin =
-    Plugin("app.cash.microfilm", AbstractGradleProject.PLUGIN_UNDER_TEST_VERSION)
+    Plugin("xyz.block.microfilm", AbstractGradleProject.PLUGIN_UNDER_TEST_VERSION)
 
   private fun androidAppProject(additions: String = "") =
     MicrofilmProject()

--- a/plugin/src/functionalTest/kotlin/xyz/block/microfilm/MicrofilmProject.kt
+++ b/plugin/src/functionalTest/kotlin/xyz/block/microfilm/MicrofilmProject.kt
@@ -1,4 +1,4 @@
-package app.cash.microfilm
+package xyz.block.microfilm
 
 import com.autonomousapps.kit.AbstractGradleProject
 import com.autonomousapps.kit.GradleProject

--- a/plugin/src/main/kotlin/xyz/block/microfilm/CompressTask.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/CompressTask.kt
@@ -1,4 +1,4 @@
-package app.cash.microfilm
+package xyz.block.microfilm
 
 import java.io.ByteArrayOutputStream
 import java.io.File

--- a/plugin/src/main/kotlin/xyz/block/microfilm/ExtractCwebpBinary.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/ExtractCwebpBinary.kt
@@ -1,4 +1,4 @@
-package app.cash.microfilm
+package xyz.block.microfilm
 
 import java.util.zip.ZipInputStream
 import org.gradle.api.artifacts.transform.CacheableTransform

--- a/plugin/src/main/kotlin/xyz/block/microfilm/Files.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/Files.kt
@@ -1,4 +1,4 @@
-package app.cash.microfilm
+package xyz.block.microfilm
 
 import java.io.File
 import java.security.MessageDigest

--- a/plugin/src/main/kotlin/xyz/block/microfilm/Manifest.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/Manifest.kt
@@ -1,4 +1,4 @@
-package app.cash.microfilm
+package xyz.block.microfilm
 
 import kotlinx.serialization.Serializable
 

--- a/plugin/src/main/kotlin/xyz/block/microfilm/MicrofilmExtension.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/MicrofilmExtension.kt
@@ -1,4 +1,4 @@
-package app.cash.microfilm
+package xyz.block.microfilm
 
 import org.gradle.api.provider.Property
 

--- a/plugin/src/main/kotlin/xyz/block/microfilm/MicrofilmPlugin.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/MicrofilmPlugin.kt
@@ -1,4 +1,4 @@
-package app.cash.microfilm
+package xyz.block.microfilm
 
 import com.android.build.api.dsl.CommonExtension
 import org.gradle.api.Plugin
@@ -46,7 +46,7 @@ class MicrofilmPlugin : Plugin<Project> {
       }
     dependencies.add(
       cwebpConfiguration.name,
-      "app.cash.microfilm:cwebp:${BuildConfig.microfilmVersion}",
+      "xyz.block.microfilm:cwebp:${BuildConfig.microfilmVersion}",
     )
 
     // Register an artifact transform to extract the cwebp binary from its JAR

--- a/plugin/src/main/kotlin/xyz/block/microfilm/VerifyTask.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/VerifyTask.kt
@@ -1,4 +1,4 @@
-package app.cash.microfilm
+package xyz.block.microfilm
 
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.CacheableTask

--- a/sample/app/build.gradle.kts
+++ b/sample/app/build.gradle.kts
@@ -1,14 +1,14 @@
 plugins {
   alias(libs.plugins.androidApplication)
   alias(libs.plugins.kotlinCompose)
-  id("app.cash.microfilm")
+  id("xyz.block.microfilm")
 }
 
 android {
-  namespace = "app.cash.microfilm.sample.app"
+  namespace = "xyz.block.microfilm.sample.app"
   compileSdk = 36
   defaultConfig {
-    applicationId = "app.cash.microfilm.sample"
+    applicationId = "xyz.block.microfilm.sample"
     minSdk = 24
     targetSdk = 36
   }

--- a/sample/app/src/main/kotlin/xyz/block/microfilm/sample/app/MainActivity.kt
+++ b/sample/app/src/main/kotlin/xyz/block/microfilm/sample/app/MainActivity.kt
@@ -1,4 +1,4 @@
-package app.cash.microfilm.sample.app
+package xyz.block.microfilm.sample.app
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
@@ -15,8 +15,8 @@ import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
-import app.cash.microfilm.sample.app.R as AppR
-import app.cash.microfilm.sample.library.R as LibraryR
+import xyz.block.microfilm.sample.app.R as AppR
+import xyz.block.microfilm.sample.library.R as LibraryR
 
 class MainActivity : ComponentActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {

--- a/sample/library/build.gradle.kts
+++ b/sample/library/build.gradle.kts
@@ -1,10 +1,10 @@
 plugins {
   alias(libs.plugins.androidLibrary)
-  id("app.cash.microfilm")
+  id("xyz.block.microfilm")
 }
 
 android {
-  namespace = "app.cash.microfilm.sample.library"
+  namespace = "xyz.block.microfilm.sample.library"
   compileSdk = 36
   defaultConfig { minSdk = 24 }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -23,6 +23,6 @@ include(":cwebp", ":plugin", ":sample:app", ":sample:library")
 
 includeBuild("build-logic") {
   dependencySubstitution {
-    substitute(module("app.cash.microfilm:plugin")).using(project(":plugin"))
+    substitute(module("xyz.block.microfilm:plugin")).using(project(":plugin"))
   }
 }


### PR DESCRIPTION
I'd rather publish this under the Cash App org, but the repo is currently in the Block org, and it sounds like the guidance is to keep it there. So be it! I'm updating the package from `app.cash.microfilm` to `xyz.block.microfilm` to match.