### PR TITLE
Add support for customizing compression within a module

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ testkit = "0.18"
 [libraries]
 agp = { module = "com.android.tools.build:gradle", version.ref = "agp" }
 androidActivityCompose = "androidx.activity:activity-compose:1.13.0"
+assertk = "com.willowtreeapps.assertk:assertk:0.28.1"
 composeMaterial = "androidx.compose.material:material:1.10.6"
 composeUi = "androidx.compose.ui:ui:1.10.6"
 junit-bom = "org.junit:junit-bom:5.12.2"
@@ -14,7 +15,6 @@ junit-jupiter = { module = "org.junit.jupiter:junit-jupiter" }
 junit-launcher = { module = "org.junit.platform:junit-platform-launcher" }
 kotlinx-serialization-json = "org.jetbrains.kotlinx:kotlinx-serialization-json:1.11.0"
 ktfmt = "com.facebook:ktfmt:0.62"
-truth = "com.google.truth:truth:1.4.4"
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -32,6 +32,11 @@ dependencies {
 
   implementation(libs.kotlinx.serialization.json)
 
+  testImplementation(libs.assertk)
+  testImplementation(platform(libs.junit.bom))
+  testImplementation(libs.junit.jupiter)
+  testRuntimeOnly(libs.junit.launcher)
+
   functionalTestImplementation(platform(libs.junit.bom))
   functionalTestImplementation(libs.junit.jupiter)
   functionalTestRuntimeOnly(libs.junit.launcher)

--- a/plugin/src/functionalTest/kotlin/xyz/block/microfilm/MicrofilmPluginFunctionalTest.kt
+++ b/plugin/src/functionalTest/kotlin/xyz/block/microfilm/MicrofilmPluginFunctionalTest.kt
@@ -17,7 +17,7 @@ class MicrofilmPluginFunctionalTest {
   private val microfilmPlugin =
     Plugin("xyz.block.microfilm", AbstractGradleProject.PLUGIN_UNDER_TEST_VERSION)
 
-  private fun androidAppProject(additions: String = "") =
+  private fun androidAppProject(additions: String = MICROFILM_CONFIGURATION) =
     MicrofilmProject()
       .androidApp(
         androidAppPlugin = androidAppPlugin,
@@ -25,7 +25,7 @@ class MicrofilmPluginFunctionalTest {
         additions = additions,
       )
 
-  private fun androidLibProject(additions: String = "") =
+  private fun androidLibProject(additions: String = MICROFILM_CONFIGURATION) =
     MicrofilmProject()
       .androidLib(
         androidLibPlugin = androidLibPlugin,
@@ -112,5 +112,20 @@ class MicrofilmPluginFunctionalTest {
     // Second build reuses the configuration cache
     val result2 = project.build(":app:compressMicrofilm", "--configuration-cache")
     assertThat(result2.output).contains("Configuration cache entry reused")
+  }
+
+  companion object {
+    private val MICROFILM_CONFIGURATION =
+      """
+      microfilm {
+        lossless = true
+
+        images("**/lossy_*.png") {
+          lossless = false
+          quality = 100
+        }
+      }
+      """
+        .trimIndent()
   }
 }

--- a/plugin/src/main/kotlin/xyz/block/microfilm/CompressTask.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/CompressTask.kt
@@ -9,7 +9,7 @@ import kotlinx.serialization.json.Json
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
-import org.gradle.api.provider.Property
+import org.gradle.api.provider.ListProperty
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.PathSensitive
@@ -29,9 +29,7 @@ abstract class CompressTask @Inject constructor(private val execOperations: Exec
 
   @get:Internal abstract val resourcesDirectory: DirectoryProperty
 
-  @get:Internal abstract val lossless: Property<Boolean>
-
-  @get:Internal abstract val quality: Property<Int>
+  @get:Internal abstract val rules: ListProperty<CompressionRule>
 
   private val microfilmDirectoryFile by lazy { microfilmDirectory.get().asFile }
   private val microfilmManifestFile by lazy { File(microfilmDirectoryFile, "manifest.json") }
@@ -66,6 +64,9 @@ abstract class CompressTask @Inject constructor(private val execOperations: Exec
     // Compress the microfilm PNGs to WebP in the resources directory
     val cwebpExecutable = cwebpDirectory.singleFile.resolve("cwebp")
     microfilmPngs.forEach { microfilmPng ->
+      val sourcePath =
+        microfilmPng.relativeTo(base = microfilmDirectoryFile).invariantSeparatorsPath
+      val rule = rules.get().resolve(imagePath = sourcePath)
       val resourcesWebp = microfilmPngToResourcesWebp(microfilmPng = microfilmPng)
       resourcesWebp.parentFile?.mkdirs()
       execOperations.exec { action ->
@@ -74,11 +75,11 @@ abstract class CompressTask @Inject constructor(private val execOperations: Exec
             add(cwebpExecutable.absolutePath)
             add("-metadata")
             add("icc")
-            if (lossless.get()) {
+            if (rule.compressionSettings.lossless) {
               add("-lossless")
             } else {
               add("-q")
-              add(quality.get().toString())
+              add(rule.compressionSettings.quality!!.toString())
             }
             add("-o")
             add(resourcesWebp.absolutePath)
@@ -103,10 +104,12 @@ abstract class CompressTask @Inject constructor(private val execOperations: Exec
           microfilmPngs
             .sortedBy { it.invariantSeparatorsPath }
             .map { microfilmPng ->
+              val sourcePath =
+                microfilmPng.relativeTo(base = microfilmDirectoryFile).invariantSeparatorsPath
+              val rule = rules.get().resolve(imagePath = sourcePath)
               val resourcesWebp = microfilmPngToResourcesWebp(microfilmPng = microfilmPng)
               Manifest.Entry(
-                sourcePath =
-                  microfilmPng.relativeTo(base = microfilmDirectoryFile).invariantSeparatorsPath,
+                sourcePath = sourcePath,
                 sourceSha256 = microfilmPng.sha256(),
                 compressedPath =
                   resourcesWebp.relativeTo(base = resourcesDirectoryFile).invariantSeparatorsPath,
@@ -115,8 +118,8 @@ abstract class CompressTask @Inject constructor(private val execOperations: Exec
                   Manifest.Compressor(
                     name = "cwebp",
                     version = cwebpVersion,
-                    lossless = lossless.get(),
-                    quality = quality.get(),
+                    lossless = rule.compressionSettings.lossless,
+                    quality = rule.compressionSettings.quality,
                   ),
               )
             }

--- a/plugin/src/main/kotlin/xyz/block/microfilm/CompressionRule.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/CompressionRule.kt
@@ -1,0 +1,18 @@
+package xyz.block.microfilm
+
+import java.io.Serializable
+import java.nio.file.FileSystems
+import java.nio.file.Path
+
+data class CompressionRule(val pattern: String, val compressionSettings: CompressionSettings) :
+  Serializable
+
+/** Returns true if the [CompressionRule] matches the given image. */
+internal fun CompressionRule.matches(imagePath: String): Boolean =
+  FileSystems.getDefault().getPathMatcher("glob:$pattern").matches(Path.of(imagePath))
+
+/** Returns the last [CompressionRule] that applies to the given image. */
+internal fun List<CompressionRule>.resolve(imagePath: String): CompressionRule =
+  last { compressionRule ->
+    compressionRule.matches(imagePath)
+  }

--- a/plugin/src/main/kotlin/xyz/block/microfilm/CompressionSettings.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/CompressionSettings.kt
@@ -1,0 +1,37 @@
+package xyz.block.microfilm
+
+import org.gradle.api.provider.Property
+
+data class CompressionSettings(val lossless: Boolean, val quality: Int?) {
+  init {
+    if (quality != null) {
+      require(quality in 0..100) { "quality must be between 0 and 100" }
+    }
+  }
+
+  abstract class Spec {
+    /** Specifies whether the WebP compression is lossless or lossy. */
+    abstract val lossless: Property<Boolean>
+
+    /** Specifies the WebP compression quality (0-100). Must not be set when [lossless] is true. */
+    abstract val quality: Property<Int>
+
+    init {
+      lossless.convention(true)
+    }
+
+    internal fun resolve(): CompressionSettings {
+      val resolvedLossless = lossless.get()
+      val resolvedQuality = quality.orNull
+      return if (resolvedLossless) {
+        CompressionSettings(lossless = true, quality = null)
+      } else {
+        CompressionSettings(lossless = false, quality = resolvedQuality ?: DEFAULT_QUALITY)
+      }
+    }
+  }
+
+  companion object {
+    private const val DEFAULT_QUALITY = 90
+  }
+}

--- a/plugin/src/main/kotlin/xyz/block/microfilm/MicrofilmExtension.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/MicrofilmExtension.kt
@@ -1,11 +1,34 @@
 package xyz.block.microfilm
 
-import org.gradle.api.provider.Property
+import javax.inject.Inject
+import org.gradle.api.Action
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Provider
+import org.gradle.api.provider.ProviderFactory
 
-abstract class MicrofilmExtension {
-  /** Specifies whether the WebP compression is lossless or lossy. */
-  abstract val lossless: Property<Boolean>
+abstract class MicrofilmExtension : CompressionSettings.Spec() {
+  @get:Inject internal abstract val objects: ObjectFactory
+  @get:Inject internal abstract val providers: ProviderFactory
 
-  /** Specifies the WebP compression quality (0-100). Ignored when [lossless] is true. */
-  abstract val quality: Property<Int>
+  internal val compressionRules: Provider<List<CompressionRule>>
+    get() = providers.provider {
+      buildList {
+        add(CompressionRule(pattern = "**", compressionSettings = resolve()))
+        addAll(compressionRuleOverrides.get())
+      }
+    }
+
+  internal abstract val compressionRuleOverrides: ListProperty<CompressionRule>
+
+  /** Overrides the default compression settings for images matching the given glob [pattern]. */
+  fun images(pattern: String, action: Action<CompressionSettings.Spec>) {
+    val spec = objects.newInstance(CompressionSettings.Spec::class.java)
+    action.execute(spec)
+    compressionRuleOverrides.add(
+      providers.provider {
+        CompressionRule(pattern = pattern, compressionSettings = spec.resolve())
+      }
+    )
+  }
 }

--- a/plugin/src/main/kotlin/xyz/block/microfilm/MicrofilmPlugin.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/MicrofilmPlugin.kt
@@ -19,10 +19,8 @@ import org.gradle.nativeplatform.OperatingSystemFamily.OPERATING_SYSTEM_ATTRIBUT
 
 class MicrofilmPlugin : Plugin<Project> {
   override fun apply(target: Project): Unit = target.run {
-    // Configure the extension and set the default values
+    // Configure the extension
     val extension = extensions.create("microfilm", MicrofilmExtension::class.java)
-    extension.lossless.convention(true)
-    extension.quality.convention(90)
 
     // Create a resolvable configuration for the platform-specific cwebp JAR
     val cwebpConfiguration =
@@ -116,8 +114,7 @@ class MicrofilmPlugin : Plugin<Project> {
           task.cwebpDirectory.from(cwebpDirectory)
           task.microfilmDirectory.set(layout.projectDirectory.dir("src/$name/microfilm"))
           task.resourcesDirectory.set(layout.projectDirectory.dir("src/$name/res"))
-          task.lossless.set(extension.lossless)
-          task.quality.set(extension.quality)
+          task.rules.set(extension.compressionRules)
           task.outputs.upToDateWhen { false }
         }
       val verifySourceSet =

--- a/plugin/src/test/kotlin/xyz/block/microfilm/CompressionRuleTest.kt
+++ b/plugin/src/test/kotlin/xyz/block/microfilm/CompressionRuleTest.kt
@@ -1,0 +1,62 @@
+package xyz.block.microfilm
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
+import org.junit.jupiter.api.Test
+
+class CompressionRuleTest {
+  @Test
+  fun `matches path exactly`() {
+    val compressionRule = CompressionRule(pattern = "drawable-mdpi/photo.png")
+
+    assertThat(compressionRule.matches(imagePath = "drawable-mdpi/photo.png")).isTrue()
+    assertThat(compressionRule.matches(imagePath = "drawable-hdpi/photo_1.png")).isFalse()
+    assertThat(compressionRule.matches(imagePath = "drawable-hdpi/photo_2.png")).isFalse()
+  }
+
+  @Test
+  fun `matches path with wildcards`() {
+    val compressionRule = CompressionRule(pattern = "**/photo_*.png")
+
+    assertThat(compressionRule.matches(imagePath = "drawable-mdpi/photo.png")).isFalse()
+    assertThat(compressionRule.matches(imagePath = "drawable-hdpi/photo_1.png")).isTrue()
+    assertThat(compressionRule.matches(imagePath = "drawable-hdpi/photo_2.png")).isTrue()
+  }
+
+  @Test
+  fun `matches fallback`() {
+    val compressionRule = CompressionRule(pattern = "**")
+
+    assertThat(compressionRule.matches(imagePath = "drawable-mdpi/photo.png")).isTrue()
+    assertThat(compressionRule.matches(imagePath = "drawable-hdpi/photo_1.png")).isTrue()
+    assertThat(compressionRule.matches(imagePath = "drawable-hdpi/photo_2.png")).isTrue()
+  }
+
+  @Test
+  fun `resolve override`() {
+    val fallback = CompressionRule(pattern = "**")
+    val mdpi = CompressionRule(pattern = "drawable-mdpi/**")
+    val hdpi = CompressionRule(pattern = "drawable-hdpi/**")
+    val compressionRules = listOf(fallback, mdpi, hdpi)
+
+    assertThat(compressionRules.resolve(imagePath = "drawable-mdpi/photo.png")).isEqualTo(mdpi)
+  }
+
+  @Test
+  fun `resolve fallback`() {
+    val fallback = CompressionRule(pattern = "**")
+    val mdpi = CompressionRule(pattern = "drawable-mdpi/**")
+    val hdpi = CompressionRule(pattern = "drawable-hdpi/**")
+    val compressionRules = listOf(fallback, mdpi, hdpi)
+
+    assertThat(compressionRules.resolve(imagePath = "drawable-xhdpi/photo.png")).isEqualTo(fallback)
+  }
+
+  private fun CompressionRule(pattern: String) =
+    CompressionRule(
+      pattern = pattern,
+      compressionSettings = CompressionSettings(lossless = true, quality = null),
+    )
+}

--- a/plugin/src/test/kotlin/xyz/block/microfilm/CompressionSettingsTest.kt
+++ b/plugin/src/test/kotlin/xyz/block/microfilm/CompressionSettingsTest.kt
@@ -1,0 +1,14 @@
+package xyz.block.microfilm
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class CompressionSettingsTest {
+  @Test
+  fun `init validates quality range`() {
+    assertThrows<IllegalArgumentException> { CompressionSettings(lossless = true, quality = -1) }
+    CompressionSettings(lossless = true, quality = 0)
+    CompressionSettings(lossless = true, quality = 100)
+    assertThrows<IllegalArgumentException> { CompressionSettings(lossless = true, quality = 101) }
+  }
+}


### PR DESCRIPTION
Right now we apply a single set of compression settings to every image in a module. I'm adding the option to have multiple rules targeting specific subsets of images within a module, in addition to the default. So for example you might have something like this:
```kotlin
microfilm {
  lossless = true

  images("**/lossy_*.png") {
    lossless = false
    quality = 100
  }
}
```