### PR TITLE
Align more closely with the cwebp options

### DIFF
--- a/plugin/src/functionalTest/kotlin/xyz/block/microfilm/MicrofilmPluginFunctionalTest.kt
+++ b/plugin/src/functionalTest/kotlin/xyz/block/microfilm/MicrofilmPluginFunctionalTest.kt
@@ -122,7 +122,7 @@ class MicrofilmPluginFunctionalTest {
 
         images("**/lossy_*.png") {
           lossless = false
-          quality = 100
+          compressionFactor = 100
         }
       }
       """

--- a/plugin/src/main/kotlin/xyz/block/microfilm/CompressTask.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/CompressTask.kt
@@ -77,9 +77,10 @@ abstract class CompressTask @Inject constructor(private val execOperations: Exec
             add("icc")
             if (rule.compressionSettings.lossless) {
               add("-lossless")
-            } else {
+            }
+            rule.compressionSettings.compressionFactor?.let { compressionFactor ->
               add("-q")
-              add(rule.compressionSettings.quality!!.toString())
+              add(compressionFactor.toString())
             }
             add("-o")
             add(resourcesWebp.absolutePath)
@@ -119,7 +120,7 @@ abstract class CompressTask @Inject constructor(private val execOperations: Exec
                     name = "cwebp",
                     version = cwebpVersion,
                     lossless = rule.compressionSettings.lossless,
-                    quality = rule.compressionSettings.quality,
+                    compressionFactor = rule.compressionSettings.compressionFactor,
                   ),
               )
             }

--- a/plugin/src/main/kotlin/xyz/block/microfilm/CompressionSettings.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/CompressionSettings.kt
@@ -2,36 +2,46 @@ package xyz.block.microfilm
 
 import org.gradle.api.provider.Property
 
-data class CompressionSettings(val lossless: Boolean, val quality: Int?) {
+data class CompressionSettings(val lossless: Boolean, val compressionFactor: Int?) {
   init {
-    if (quality != null) {
-      require(quality in 0..100) { "quality must be between 0 and 100" }
+    if (compressionFactor != null) {
+      require(compressionFactor in 0..100) { "compressionFactor must be between 0 and 100" }
     }
   }
 
   abstract class Spec {
-    /** Specifies whether the WebP compression is lossless or lossy. */
+    /**
+     * Specifies whether the WebP compression is lossy or lossless. The default is false.
+     *
+     * See the cwebp documentation of the -lossless option for more info:
+     * https://developers.google.com/speed/webp/docs/cwebp
+     */
     abstract val lossless: Property<Boolean>
 
-    /** Specifies the WebP compression quality (0-100). Must not be set when [lossless] is true. */
-    abstract val quality: Property<Int>
+    /**
+     * Specify the compression factor for RGB channels between 0 and 100. The default is 75.
+     *
+     * In case of lossy compression (default), a small factor produces a smaller file with lower
+     * quality. Best quality is achieved by using a value of 100.
+     *
+     * In case of lossless compression (specified by the -lossless option), a small factor enables
+     * faster compression speed, but produces a larger file. Maximum compression is achieved by
+     * using a value of 100.
+     *
+     * See the cwebp documentation of the -q option for more info:
+     * https://developers.google.com/speed/webp/docs/cwebp
+     */
+    abstract val compressionFactor: Property<Int>
 
     init {
-      lossless.convention(true)
+      lossless.convention(false)
     }
 
     internal fun resolve(): CompressionSettings {
-      val resolvedLossless = lossless.get()
-      val resolvedQuality = quality.orNull
-      return if (resolvedLossless) {
-        CompressionSettings(lossless = true, quality = null)
-      } else {
-        CompressionSettings(lossless = false, quality = resolvedQuality ?: DEFAULT_QUALITY)
-      }
+      return CompressionSettings(
+        lossless = lossless.get(),
+        compressionFactor = compressionFactor.orNull,
+      )
     }
-  }
-
-  companion object {
-    private const val DEFAULT_QUALITY = 90
   }
 }

--- a/plugin/src/main/kotlin/xyz/block/microfilm/Manifest.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/Manifest.kt
@@ -18,6 +18,6 @@ data class Manifest(val entries: List<Entry> = emptyList()) {
     val name: String,
     val version: String,
     val lossless: Boolean,
-    val quality: Int?,
+    val compressionFactor: Int?,
   )
 }

--- a/plugin/src/test/kotlin/xyz/block/microfilm/CompressionRuleTest.kt
+++ b/plugin/src/test/kotlin/xyz/block/microfilm/CompressionRuleTest.kt
@@ -57,6 +57,6 @@ class CompressionRuleTest {
   private fun CompressionRule(pattern: String) =
     CompressionRule(
       pattern = pattern,
-      compressionSettings = CompressionSettings(lossless = true, quality = null),
+      compressionSettings = CompressionSettings(lossless = true, compressionFactor = null),
     )
 }

--- a/plugin/src/test/kotlin/xyz/block/microfilm/CompressionSettingsTest.kt
+++ b/plugin/src/test/kotlin/xyz/block/microfilm/CompressionSettingsTest.kt
@@ -5,10 +5,17 @@ import org.junit.jupiter.api.assertThrows
 
 class CompressionSettingsTest {
   @Test
-  fun `init validates quality range`() {
-    assertThrows<IllegalArgumentException> { CompressionSettings(lossless = true, quality = -1) }
-    CompressionSettings(lossless = true, quality = 0)
-    CompressionSettings(lossless = true, quality = 100)
-    assertThrows<IllegalArgumentException> { CompressionSettings(lossless = true, quality = 101) }
+  fun `init validates compressionFactor range`() {
+    assertThrows<IllegalArgumentException> {
+      CompressionSettings(lossless = true, compressionFactor = -1)
+    }
+
+    CompressionSettings(lossless = true, compressionFactor = null)
+    CompressionSettings(lossless = true, compressionFactor = 0)
+    CompressionSettings(lossless = true, compressionFactor = 100)
+
+    assertThrows<IllegalArgumentException> {
+      CompressionSettings(lossless = true, compressionFactor = 101)
+    }
   }
 }


### PR DESCRIPTION
I misunderstood how the `-q` flag works in `cwebp`. I initially thought that it only set the quality for lossy compression, but it also determines the "compression factor" for lossless compression. Basically it trades off compression speed against final file size. I'm renaming the option to match the `cwebp` documentation and updating how we handle it.