### PR TITLE
Remove the default compression configuration

### DIFF
--- a/plugin/src/functionalTest/kotlin/xyz/block/microfilm/MicrofilmPluginFunctionalTest.kt
+++ b/plugin/src/functionalTest/kotlin/xyz/block/microfilm/MicrofilmPluginFunctionalTest.kt
@@ -118,9 +118,11 @@ class MicrofilmPluginFunctionalTest {
     private val MICROFILM_CONFIGURATION =
       """
       microfilm {
-        lossless = true
+        compress {
+          lossless = true
+        }
 
-        images("**/lossy_*.png") {
+        compress("**/lossy_*.png") {
           lossless = false
           compressionFactor = 100
         }

--- a/plugin/src/main/kotlin/xyz/block/microfilm/CompressTask.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/CompressTask.kt
@@ -47,12 +47,16 @@ abstract class CompressTask @Inject constructor(private val execOperations: Exec
         .toList()
 
     // Sweep the resources PNGs to the microfilm directory
-    resourcesPngs.forEach { resourcesPng ->
-      val microfilmPng = resourcesPngToMicrofilmPng(resourcesPng = resourcesPng)
-      microfilmPng.parentFile?.mkdirs()
-      resourcesPng.copyTo(target = microfilmPng, overwrite = true)
-      resourcesPng.delete()
-    }
+    resourcesPngs
+      .filter { resourcesPng ->
+        resourcesPng.relativeTo(base = resourcesDirectoryFile).resolveRule() != null
+      }
+      .forEach { resourcesPng ->
+        val microfilmPng = resourcesPngToMicrofilmPng(resourcesPng = resourcesPng)
+        microfilmPng.parentFile?.mkdirs()
+        resourcesPng.copyTo(target = microfilmPng, overwrite = true)
+        resourcesPng.delete()
+      }
 
     // Find the microfilm PNGs
     val microfilmPngs =
@@ -63,32 +67,35 @@ abstract class CompressTask @Inject constructor(private val execOperations: Exec
 
     // Compress the microfilm PNGs to WebP in the resources directory
     val cwebpExecutable = cwebpDirectory.singleFile.resolve("cwebp")
-    microfilmPngs.forEach { microfilmPng ->
-      val sourcePath =
-        microfilmPng.relativeTo(base = microfilmDirectoryFile).invariantSeparatorsPath
-      val rule = rules.get().resolve(imagePath = sourcePath)
-      val resourcesWebp = microfilmPngToResourcesWebp(microfilmPng = microfilmPng)
-      resourcesWebp.parentFile?.mkdirs()
-      execOperations.exec { action ->
-        action.commandLine(
-          buildList {
-            add(cwebpExecutable.absolutePath)
-            add("-metadata")
-            add("icc")
-            if (rule.compressionSettings.lossless) {
-              add("-lossless")
-            }
-            rule.compressionSettings.compressionFactor?.let { compressionFactor ->
-              add("-q")
-              add(compressionFactor.toString())
-            }
-            add("-o")
-            add(resourcesWebp.absolutePath)
-            add(microfilmPng.absolutePath)
-          }
-        )
+    microfilmPngs
+      .mapNotNull { microfilmPng ->
+        microfilmPng.relativeTo(base = microfilmDirectoryFile).resolveRule()?.let {
+          microfilmPng to it
+        }
       }
-    }
+      .forEach { (microfilmPng, rule) ->
+        val resourcesWebp = microfilmPngToResourcesWebp(microfilmPng = microfilmPng)
+        resourcesWebp.parentFile?.mkdirs()
+        execOperations.exec { action ->
+          action.commandLine(
+            buildList {
+              add(cwebpExecutable.absolutePath)
+              add("-metadata")
+              add("icc")
+              if (rule.compressionSettings.lossless) {
+                add("-lossless")
+              }
+              rule.compressionSettings.compressionFactor?.let { compressionFactor ->
+                add("-q")
+                add(compressionFactor.toString())
+              }
+              add("-o")
+              add(resourcesWebp.absolutePath)
+              add(microfilmPng.absolutePath)
+            }
+          )
+        }
+      }
 
     // Get the current cwebp version
     val output = ByteArrayOutputStream()
@@ -103,14 +110,17 @@ abstract class CompressTask @Inject constructor(private val execOperations: Exec
       Manifest(
         entries =
           microfilmPngs
-            .sortedBy { it.invariantSeparatorsPath }
-            .map { microfilmPng ->
-              val sourcePath =
-                microfilmPng.relativeTo(base = microfilmDirectoryFile).invariantSeparatorsPath
-              val rule = rules.get().resolve(imagePath = sourcePath)
+            .sortedBy { microfilmPng -> microfilmPng.invariantSeparatorsPath }
+            .mapNotNull { microfilmPng ->
+              microfilmPng.relativeTo(base = microfilmDirectoryFile).resolveRule()?.let {
+                microfilmPng to it
+              }
+            }
+            .map { (microfilmPng, rule) ->
               val resourcesWebp = microfilmPngToResourcesWebp(microfilmPng = microfilmPng)
               Manifest.Entry(
-                sourcePath = sourcePath,
+                sourcePath =
+                  microfilmPng.relativeTo(base = microfilmDirectoryFile).invariantSeparatorsPath,
                 sourceSha256 = microfilmPng.sha256(),
                 compressedPath =
                   resourcesWebp.relativeTo(base = resourcesDirectoryFile).invariantSeparatorsPath,
@@ -150,6 +160,10 @@ abstract class CompressTask @Inject constructor(private val execOperations: Exec
         .invariantSeparatorsPath
         .replace(PNG_EXTENSION_PATTERN, ".webp"),
     )
+
+  private fun File.resolveRule(): CompressionRule? {
+    return rules.get().resolve(imagePath = invariantSeparatorsPath)
+  }
 
   companion object {
     private val DRAWABLE_DIRECTORY_PATTERN = Regex(pattern = "^drawable(-.*)?$")

--- a/plugin/src/main/kotlin/xyz/block/microfilm/CompressionRule.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/CompressionRule.kt
@@ -11,8 +11,8 @@ data class CompressionRule(val pattern: String, val compressionSettings: Compres
 internal fun CompressionRule.matches(imagePath: String): Boolean =
   FileSystems.getDefault().getPathMatcher("glob:$pattern").matches(Path.of(imagePath))
 
-/** Returns the last [CompressionRule] that applies to the given image. */
-internal fun List<CompressionRule>.resolve(imagePath: String): CompressionRule =
-  last { compressionRule ->
+/** Returns the last [CompressionRule] that matches the given image, or null if none match. */
+internal fun List<CompressionRule>.resolve(imagePath: String): CompressionRule? =
+  lastOrNull { compressionRule ->
     compressionRule.matches(imagePath)
   }

--- a/plugin/src/main/kotlin/xyz/block/microfilm/MicrofilmExtension.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/MicrofilmExtension.kt
@@ -4,28 +4,24 @@ import javax.inject.Inject
 import org.gradle.api.Action
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.ListProperty
-import org.gradle.api.provider.Provider
 import org.gradle.api.provider.ProviderFactory
 
-abstract class MicrofilmExtension : CompressionSettings.Spec() {
+abstract class MicrofilmExtension {
   @get:Inject internal abstract val objects: ObjectFactory
   @get:Inject internal abstract val providers: ProviderFactory
 
-  internal val compressionRules: Provider<List<CompressionRule>>
-    get() = providers.provider {
-      buildList {
-        add(CompressionRule(pattern = "**", compressionSettings = resolve()))
-        addAll(compressionRuleOverrides.get())
-      }
-    }
+  internal abstract val compressionRules: ListProperty<CompressionRule>
 
-  internal abstract val compressionRuleOverrides: ListProperty<CompressionRule>
+  /** Compresses all images using the given settings. */
+  fun compress(action: Action<CompressionSettings.Spec>) {
+    compress(pattern = "**", action = action)
+  }
 
-  /** Overrides the default compression settings for images matching the given glob [pattern]. */
-  fun images(pattern: String, action: Action<CompressionSettings.Spec>) {
+  /** Compresses images matching the given glob [pattern] using the given settings. */
+  fun compress(pattern: String, action: Action<CompressionSettings.Spec>) {
     val spec = objects.newInstance(CompressionSettings.Spec::class.java)
     action.execute(spec)
-    compressionRuleOverrides.add(
+    compressionRules.add(
       providers.provider {
         CompressionRule(pattern = pattern, compressionSettings = spec.resolve())
       }

--- a/plugin/src/test/kotlin/xyz/block/microfilm/CompressionRuleTest.kt
+++ b/plugin/src/test/kotlin/xyz/block/microfilm/CompressionRuleTest.kt
@@ -3,6 +3,7 @@ package xyz.block.microfilm
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
+import assertk.assertions.isNull
 import assertk.assertions.isTrue
 import org.junit.jupiter.api.Test
 
@@ -52,6 +53,15 @@ class CompressionRuleTest {
     val compressionRules = listOf(fallback, mdpi, hdpi)
 
     assertThat(compressionRules.resolve(imagePath = "drawable-xhdpi/photo.png")).isEqualTo(fallback)
+  }
+
+  @Test
+  fun `resolve nothing`() {
+    val mdpi = CompressionRule(pattern = "drawable-mdpi/**")
+    val hdpi = CompressionRule(pattern = "drawable-hdpi/**")
+    val compressionRules = listOf(mdpi, hdpi)
+
+    assertThat(compressionRules.resolve(imagePath = "drawable-xhdpi/photo.png")).isNull()
   }
 
   private fun CompressionRule(pattern: String) =

--- a/sample/app/build.gradle.kts
+++ b/sample/app/build.gradle.kts
@@ -22,6 +22,8 @@ dependencies {
 }
 
 microfilm {
-  lossless = true
-  compressionFactor = 90
+  compress {
+    lossless = true
+    compressionFactor = 90
+  }
 }

--- a/sample/library/build.gradle.kts
+++ b/sample/library/build.gradle.kts
@@ -10,6 +10,8 @@ android {
 }
 
 microfilm {
-  lossless = true
-  compressionFactor = 90
+  compress {
+    lossless = true
+    compressionFactor = 90
+  }
 }


### PR DESCRIPTION
I've been thinking about how users will configure microfilm. What we have right now is a default compression rule, with optional overrides. It looks something like this:
```kotlin
microfilm {
  lossless = true

  images("**/lossy_*.png") {
    lossless = false
    compressionFactor = 100
  }
}
```

I think the fact that there are two ways to specify compression is a little confusing, and I think that we should maybe standardize. I'm also looking forward to the next PR that I'm planning to put up to support excluding images. So I'm proposing that we remove the configuration at the top level, and do everything with explicit `compress` or `exclude` calls. Something like this:
```kotlin
microfilm {
  compress { // defaults to matching everything with "**"
    lossless = true
  }

  compress("**/lossy_*.png") {
    lossless = false
    compressionFactor = 100
  }
  
  exclude("**/excluded_*.png")
}
```