### PR TITLE
Allow users to exclude images from compression

### DIFF
--- a/plugin/src/functionalTest/kotlin/xyz/block/microfilm/MicrofilmPluginFunctionalTest.kt
+++ b/plugin/src/functionalTest/kotlin/xyz/block/microfilm/MicrofilmPluginFunctionalTest.kt
@@ -126,6 +126,8 @@ class MicrofilmPluginFunctionalTest {
           lossless = false
           compressionFactor = 100
         }
+
+        exclude("**/excluded_*.png")
       }
       """
         .trimIndent()

--- a/plugin/src/main/kotlin/xyz/block/microfilm/CompressTask.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/CompressTask.kt
@@ -17,6 +17,8 @@ import org.gradle.api.tasks.PathSensitivity.RELATIVE
 import org.gradle.api.tasks.TaskAction
 import org.gradle.process.ExecOperations
 import org.gradle.work.DisableCachingByDefault
+import xyz.block.microfilm.ImageSettings.Compress
+import xyz.block.microfilm.ImageSettings.Exclude
 
 @DisableCachingByDefault(because = "This task modifies the source tree in place")
 abstract class CompressTask @Inject constructor(private val execOperations: ExecOperations) :
@@ -49,7 +51,7 @@ abstract class CompressTask @Inject constructor(private val execOperations: Exec
     // Sweep the resources PNGs to the microfilm directory
     resourcesPngs
       .filter { resourcesPng ->
-        resourcesPng.relativeTo(base = resourcesDirectoryFile).resolveRule() != null
+        resourcesPng.relativeTo(base = resourcesDirectoryFile).resolveImageSettings() is Compress
       }
       .forEach { resourcesPng ->
         val microfilmPng = resourcesPngToMicrofilmPng(resourcesPng = resourcesPng)
@@ -69,11 +71,9 @@ abstract class CompressTask @Inject constructor(private val execOperations: Exec
     val cwebpExecutable = cwebpDirectory.singleFile.resolve("cwebp")
     microfilmPngs
       .mapNotNull { microfilmPng ->
-        microfilmPng.relativeTo(base = microfilmDirectoryFile).resolveRule()?.let {
-          microfilmPng to it
-        }
+        microfilmPng.relativeTo(base = microfilmDirectoryFile).pairWithImageSettings()
       }
-      .forEach { (microfilmPng, rule) ->
+      .forEach { (microfilmPng, imageSettings) ->
         val resourcesWebp = microfilmPngToResourcesWebp(microfilmPng = microfilmPng)
         resourcesWebp.parentFile?.mkdirs()
         execOperations.exec { action ->
@@ -82,10 +82,10 @@ abstract class CompressTask @Inject constructor(private val execOperations: Exec
               add(cwebpExecutable.absolutePath)
               add("-metadata")
               add("icc")
-              if (rule.imageSettings.lossless) {
+              if (imageSettings.lossless) {
                 add("-lossless")
               }
-              rule.imageSettings.compressionFactor?.let { compressionFactor ->
+              imageSettings.compressionFactor?.let { compressionFactor ->
                 add("-q")
                 add(compressionFactor.toString())
               }
@@ -112,11 +112,9 @@ abstract class CompressTask @Inject constructor(private val execOperations: Exec
           microfilmPngs
             .sortedBy { microfilmPng -> microfilmPng.invariantSeparatorsPath }
             .mapNotNull { microfilmPng ->
-              microfilmPng.relativeTo(base = microfilmDirectoryFile).resolveRule()?.let {
-                microfilmPng to it
-              }
+              microfilmPng.relativeTo(base = microfilmDirectoryFile).pairWithImageSettings()
             }
-            .map { (microfilmPng, rule) ->
+            .map { (microfilmPng, imageSettings) ->
               val resourcesWebp = microfilmPngToResourcesWebp(microfilmPng = microfilmPng)
               Manifest.Entry(
                 sourcePath =
@@ -129,8 +127,8 @@ abstract class CompressTask @Inject constructor(private val execOperations: Exec
                   Manifest.Compressor(
                     name = "cwebp",
                     version = cwebpVersion,
-                    lossless = rule.imageSettings.lossless,
-                    compressionFactor = rule.imageSettings.compressionFactor,
+                    lossless = imageSettings.lossless,
+                    compressionFactor = imageSettings.compressionFactor,
                   ),
               )
             }
@@ -161,8 +159,13 @@ abstract class CompressTask @Inject constructor(private val execOperations: Exec
         .replace(PNG_EXTENSION_PATTERN, ".webp"),
     )
 
-  private fun File.resolveRule(): ImageRule? {
-    return rules.get().resolve(imagePath = invariantSeparatorsPath)
+  private fun File.pairWithImageSettings(): Pair<File, Compress>? {
+    val imageSettings = resolveImageSettings()
+    return if (imageSettings is Compress) this to imageSettings else null
+  }
+
+  private fun File.resolveImageSettings(): ImageSettings {
+    return rules.get().resolve(imagePath = invariantSeparatorsPath)?.imageSettings ?: Exclude
   }
 
   companion object {

--- a/plugin/src/main/kotlin/xyz/block/microfilm/ImageSettings.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/ImageSettings.kt
@@ -2,43 +2,46 @@ package xyz.block.microfilm
 
 import org.gradle.api.provider.Property
 
-data class ImageSettings(val lossless: Boolean, val compressionFactor: Int?) {
-  init {
-    if (compressionFactor != null) {
-      require(compressionFactor in 0..100) { "compressionFactor must be between 0 and 100" }
-    }
-  }
-
-  abstract class Spec {
-    /**
-     * Specifies whether the WebP compression is lossy or lossless. The default is false.
-     *
-     * See the cwebp documentation of the -lossless option for more info:
-     * https://developers.google.com/speed/webp/docs/cwebp
-     */
-    abstract val lossless: Property<Boolean>
-
-    /**
-     * Specify the compression factor for RGB channels between 0 and 100. The default is 75.
-     *
-     * In case of lossy compression (default), a small factor produces a smaller file with lower
-     * quality. Best quality is achieved by using a value of 100.
-     *
-     * In case of lossless compression (specified by the -lossless option), a small factor enables
-     * faster compression speed, but produces a larger file. Maximum compression is achieved by
-     * using a value of 100.
-     *
-     * See the cwebp documentation of the -q option for more info:
-     * https://developers.google.com/speed/webp/docs/cwebp
-     */
-    abstract val compressionFactor: Property<Int>
-
+sealed interface ImageSettings {
+  data class Compress(val lossless: Boolean, val compressionFactor: Int?) : ImageSettings {
     init {
-      lossless.convention(false)
+      if (compressionFactor != null) {
+        require(compressionFactor in 0..100) { "compressionFactor must be between 0 and 100" }
+      }
     }
 
-    internal fun resolve(): ImageSettings {
-      return ImageSettings(lossless = lossless.get(), compressionFactor = compressionFactor.orNull)
+    abstract class Spec {
+      /**
+       * Specifies whether the WebP compression is lossy or lossless. The default is false.
+       *
+       * See the cwebp documentation of the -lossless option for more info:
+       * https://developers.google.com/speed/webp/docs/cwebp
+       */
+      abstract val lossless: Property<Boolean>
+
+      /**
+       * Specify the compression factor for RGB channels between 0 and 100. The default is 75.
+       *
+       * In case of lossy compression (default), a small factor produces a smaller file with lower
+       * quality. Best quality is achieved by using a value of 100.
+       *
+       * In case of lossless compression (specified by the -lossless option), a small factor enables
+       * faster compression speed, but produces a larger file. Maximum compression is achieved by
+       * using a value of 100.
+       *
+       * See the cwebp documentation of the -q option for more info:
+       * https://developers.google.com/speed/webp/docs/cwebp
+       */
+      abstract val compressionFactor: Property<Int>
+
+      init {
+        lossless.convention(false)
+      }
+
+      internal fun resolve(): Compress =
+        Compress(lossless = lossless.get(), compressionFactor = compressionFactor.orNull)
     }
   }
+
+  data object Exclude : ImageSettings
 }

--- a/plugin/src/main/kotlin/xyz/block/microfilm/MicrofilmExtension.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/MicrofilmExtension.kt
@@ -5,6 +5,7 @@ import org.gradle.api.Action
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.ProviderFactory
+import xyz.block.microfilm.ImageSettings.Exclude
 
 abstract class MicrofilmExtension {
   @get:Inject internal abstract val objects: ObjectFactory
@@ -12,17 +13,18 @@ abstract class MicrofilmExtension {
 
   internal abstract val imageRules: ListProperty<ImageRule>
 
-  /** Compresses all images using the given settings. */
-  fun compress(action: Action<ImageSettings.Spec>) {
-    compress(pattern = "**", action = action)
-  }
-
-  /** Compresses images matching the given glob [pattern] using the given settings. */
-  fun compress(pattern: String, action: Action<ImageSettings.Spec>) {
-    val spec = objects.newInstance(ImageSettings.Spec::class.java)
+  /** Compresses the images matching the given glob [pattern]. Matches all images by default. */
+  @JvmOverloads
+  fun compress(pattern: String = "**", action: Action<ImageSettings.Compress.Spec>) {
+    val spec = objects.newInstance(ImageSettings.Compress.Spec::class.java)
     action.execute(spec)
     imageRules.add(
       providers.provider { ImageRule(pattern = pattern, imageSettings = spec.resolve()) }
     )
+  }
+
+  /** Excludes the images matching the given glob [pattern]. */
+  fun exclude(pattern: String) {
+    imageRules.add(providers.provider { ImageRule(pattern = pattern, imageSettings = Exclude) })
   }
 }

--- a/plugin/src/test/kotlin/xyz/block/microfilm/ImageRuleTest.kt
+++ b/plugin/src/test/kotlin/xyz/block/microfilm/ImageRuleTest.kt
@@ -67,6 +67,6 @@ class ImageRuleTest {
   private fun ImageRule(pattern: String) =
     ImageRule(
       pattern = pattern,
-      imageSettings = ImageSettings(lossless = true, compressionFactor = null),
+      imageSettings = ImageSettings.Compress(lossless = true, compressionFactor = null),
     )
 }

--- a/plugin/src/test/kotlin/xyz/block/microfilm/ImageSettingsTest.kt
+++ b/plugin/src/test/kotlin/xyz/block/microfilm/ImageSettingsTest.kt
@@ -5,17 +5,17 @@ import org.junit.jupiter.api.assertThrows
 
 class ImageSettingsTest {
   @Test
-  fun `init validates compressionFactor range`() {
+  fun `compress init validates compressionFactor range`() {
     assertThrows<IllegalArgumentException> {
-      ImageSettings(lossless = true, compressionFactor = -1)
+      ImageSettings.Compress(lossless = true, compressionFactor = -1)
     }
 
-    ImageSettings(lossless = true, compressionFactor = null)
-    ImageSettings(lossless = true, compressionFactor = 0)
-    ImageSettings(lossless = true, compressionFactor = 100)
+    ImageSettings.Compress(lossless = true, compressionFactor = null)
+    ImageSettings.Compress(lossless = true, compressionFactor = 0)
+    ImageSettings.Compress(lossless = true, compressionFactor = 100)
 
     assertThrows<IllegalArgumentException> {
-      ImageSettings(lossless = true, compressionFactor = 101)
+      ImageSettings.Compress(lossless = true, compressionFactor = 101)
     }
   }
 }


### PR DESCRIPTION
I'm adding the ability to exclude certain image patterns from compression with `exclude`. It looks something like this:
```kotlin
microfilm {
  compress {
    lossless = true
  }

  compress("**/lossy_*.png") {
    lossless = false
    compressionFactor = 100
  }
  
  exclude("**/excluded_*.png")
}
```