### PR TITLE
Throw an error if Microfilm is applied to a non-android module

### DIFF
--- a/plugin/src/functionalTest/kotlin/xyz/block/microfilm/MicrofilmPluginFunctionalTest.kt
+++ b/plugin/src/functionalTest/kotlin/xyz/block/microfilm/MicrofilmPluginFunctionalTest.kt
@@ -59,7 +59,6 @@ class MicrofilmPluginFunctionalTest {
   }
 
   @Test
-  @Disabled("See https://linear.app/squareup/issue/TCS-780")
   fun `plugin does not apply to non-android project`() {
     val project = vanillaProject()
     val result = GradleBuilder.buildAndFail(project.rootDir, "tasks", "--group=microfilm")

--- a/plugin/src/main/kotlin/xyz/block/microfilm/MicrofilmPlugin.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/MicrofilmPlugin.kt
@@ -95,6 +95,11 @@ class MicrofilmPlugin : Plugin<Project> {
         verify = verify,
       )
     }
+    afterEvaluate {
+      check(plugins.hasPlugin(PLUGIN_ID_APPLICATION) || plugins.hasPlugin(PLUGIN_ID_LIBRARY)) {
+        "Microfilm requires either the '$PLUGIN_ID_APPLICATION' or '$PLUGIN_ID_LIBRARY' plugin."
+      }
+    }
 
     // Link the verify task to the common check task
     plugins.withId("base") { tasks.named("check").configure { it.dependsOn(verify) } }


### PR DESCRIPTION
It only makes sense to add Microfilm if the `com.android.application` or `com.android.library` plugin is also applied.