### PR TITLE
Skip the compress and verify tasks for source sets with no images

### DIFF
--- a/plugin/src/functionalTest/kotlin/xyz/block/microfilm/MicrofilmPluginFunctionalTest.kt
+++ b/plugin/src/functionalTest/kotlin/xyz/block/microfilm/MicrofilmPluginFunctionalTest.kt
@@ -70,7 +70,6 @@ class MicrofilmPluginFunctionalTest {
   }
 
   @Test
-  @Disabled("See https://linear.app/squareup/issue/TCS-708")
   fun `compress task is skipped when source set is empty`() {
     val project = androidLibProject()
     val result = project.build(":lib:compressMicrofilmMain")
@@ -137,7 +136,6 @@ class MicrofilmPluginFunctionalTest {
   }
 
   @Test
-  @Disabled("See https://linear.app/squareup/issue/TCS-708")
   fun `compress task skipped when source set has independent webp image in resources directory`() {
     val project = androidLibProject()
     WEBP_FIXTURE.copyToDirectory(directory = project.libResourcesDrawableDirectory)
@@ -245,7 +243,6 @@ class MicrofilmPluginFunctionalTest {
   }
 
   @Test
-  @Disabled("See https://linear.app/squareup/issue/TCS-708")
   fun `verify task is skipped when source set is empty`() {
     val project = androidLibProject()
     val result = project.build(":lib:verifyMicrofilmMain")
@@ -299,7 +296,6 @@ class MicrofilmPluginFunctionalTest {
   }
 
   @Test
-  @Disabled("See https://linear.app/squareup/issue/TCS-708")
   fun `verify task skipped when source set has independent webp image in resources directory`() {
     val project = androidLibProject()
     WEBP_FIXTURE_LOSSY.copyToDirectory(directory = project.libResourcesDrawableDirectory)

--- a/plugin/src/main/kotlin/xyz/block/microfilm/CompressTask.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/CompressTask.kt
@@ -40,13 +40,7 @@ abstract class CompressTask @Inject constructor(private val execOperations: Exec
   @TaskAction
   fun compress() {
     // Find the resources PNGs
-    val resourcesPngs =
-      resourcesDirectoryFile
-        .walk()
-        .filter { it.isFile && it.extension.equals("png", ignoreCase = true) }
-        .filter { !it.name.endsWith(".9.png", ignoreCase = true) }
-        .filter { it.isInDrawableDirectory() }
-        .toList()
+    val resourcesPngs = resourcesDirectoryFile.walk().filter { file -> file.isPngDrawable }.toList()
 
     // Sweep the resources PNGs to the microfilm directory
     resourcesPngs
@@ -61,11 +55,7 @@ abstract class CompressTask @Inject constructor(private val execOperations: Exec
       }
 
     // Find the microfilm PNGs
-    val microfilmPngs =
-      microfilmDirectoryFile
-        .walk()
-        .filter { it.isFile && it.extension.equals("png", ignoreCase = true) }
-        .toList()
+    val microfilmPngs = microfilmDirectoryFile.walk().filter { file -> file.isPngDrawable }.toList()
 
     // Compress the microfilm PNGs to WebP in the resources directory
     val cwebpExecutable = cwebpDirectory.singleFile.resolve("cwebp")
@@ -168,7 +158,6 @@ abstract class CompressTask @Inject constructor(private val execOperations: Exec
   }
 
   companion object {
-    private val DRAWABLE_DIRECTORY_PATTERN = Regex(pattern = "^drawable(-.*)?$")
     private val PNG_EXTENSION_PATTERN = Regex(pattern = "\\.png$", option = IGNORE_CASE)
 
     @OptIn(ExperimentalSerializationApi::class)
@@ -176,10 +165,6 @@ abstract class CompressTask @Inject constructor(private val execOperations: Exec
       encodeDefaults = true
       prettyPrint = true
       prettyPrintIndent = "  "
-    }
-
-    private fun File.isInDrawableDirectory(): Boolean {
-      return parentFile?.name?.let { DRAWABLE_DIRECTORY_PATTERN.matches(it) } == true
     }
   }
 }

--- a/plugin/src/main/kotlin/xyz/block/microfilm/Files.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/Files.kt
@@ -3,6 +3,16 @@ package xyz.block.microfilm
 import java.io.File
 import java.security.MessageDigest
 
+/** Matches Android drawable resource directories like `drawable` and `drawable-hdpi`. */
+private val DRAWABLE_DIRECTORY_PATTERN = Regex(pattern = "^drawable(-.*)?$")
+
+/** True if this is a PNG image in a drawable directory. Excludes nine-patch (`.9.png`) files. */
+internal val File.isPngDrawable: Boolean
+  get() =
+    extension.equals("png", ignoreCase = true) &&
+      !name.endsWith(".9.png", ignoreCase = true) &&
+      DRAWABLE_DIRECTORY_PATTERN.matches(input = parentFile.name)
+
 /** Produces the SHA256 hash of the given file. */
 fun File.sha256(): String {
   val digest = MessageDigest.getInstance("SHA-256")

--- a/plugin/src/main/kotlin/xyz/block/microfilm/MicrofilmPlugin.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/MicrofilmPlugin.kt
@@ -1,6 +1,7 @@
 package xyz.block.microfilm
 
 import com.android.build.api.dsl.CommonExtension
+import java.io.File
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.type.ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE
@@ -116,20 +117,29 @@ class MicrofilmPlugin : Plugin<Project> {
       val nameCapitalized = name.replaceFirstChar { it.uppercase() }
 
       // Register subtasks for each source set
+      val microfilmDirectory = layout.projectDirectory.dir("src/$name/microfilm")
+      val microfilmManifest = microfilmDirectory.file("manifest.json")
+      val resourcesDirectory = layout.projectDirectory.dir("src/$name/res")
+      fun hasMicrofilmContent() =
+        microfilmDirectory.asFile.containsPngDrawables() ||
+          microfilmManifest.asFile.exists() ||
+          resourcesDirectory.asFile.containsPngDrawables()
       val compressSourceSet =
         tasks.register("compressMicrofilm$nameCapitalized", CompressTask::class.java) { task ->
           task.description = "Compresses source images for the '$name' source set"
           task.group = "microfilm"
           task.cwebpDirectory.from(cwebpDirectory)
-          task.microfilmDirectory.set(layout.projectDirectory.dir("src/$name/microfilm"))
-          task.resourcesDirectory.set(layout.projectDirectory.dir("src/$name/res"))
+          task.microfilmDirectory.set(microfilmDirectory)
+          task.resourcesDirectory.set(resourcesDirectory)
           task.rules.set(extension.imageRules)
           task.outputs.upToDateWhen { false }
+          task.onlyIf { hasMicrofilmContent() }
         }
       val verifySourceSet =
         tasks.register("verifyMicrofilm$nameCapitalized", VerifyTask::class.java) { task ->
           task.description = "Verifies that the manifest is up to date for the '$name' source set"
           task.group = "microfilm"
+          task.onlyIf { hasMicrofilmContent() }
         }
 
       // Link the subtasks to the parent tasks
@@ -144,6 +154,8 @@ class MicrofilmPlugin : Plugin<Project> {
     private const val PLUGIN_ID_LIBRARY = "com.android.library"
   }
 }
+
+private fun File.containsPngDrawables() = walk().any { file -> file.isPngDrawable }
 
 private fun currentOperatingSystemFamily(): String {
   val operatingSystem = System.getProperty("os.name").lowercase()

--- a/plugin/src/test/kotlin/xyz/block/microfilm/FilesTest.kt
+++ b/plugin/src/test/kotlin/xyz/block/microfilm/FilesTest.kt
@@ -1,0 +1,30 @@
+package xyz.block.microfilm
+
+import assertk.assertThat
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
+import java.io.File
+import org.junit.jupiter.api.Test
+
+class FilesTest {
+  @Test
+  fun `isPngDrawable for webp drawable`() {
+    assertThat(File("src/main/drawable/image.webp").isPngDrawable).isFalse()
+  }
+
+  @Test
+  fun `isPngDrawable for png asset`() {
+    assertThat(File("src/main/asset/image.png").isPngDrawable).isFalse()
+  }
+
+  @Test
+  fun `isPngDrawable for png drawables`() {
+    assertThat(File("src/main/drawable/image.png").isPngDrawable).isTrue()
+    assertThat(File("src/main/drawable-hdpi/image.png").isPngDrawable).isTrue()
+  }
+
+  @Test
+  fun `isPngDrawable for png nine-patch`() {
+    assertThat(File("src/main/drawable/image.9.png").isPngDrawable).isFalse()
+  }
+}


### PR DESCRIPTION
If a module doesn't contain any Microfilm content (PNG drawables or a manifest) then we don't need to run the compress or verify tasks.