### PR TITLE
Implement the verify task

### DIFF
--- a/plugin/src/functionalTest/kotlin/xyz/block/microfilm/MicrofilmPluginFunctionalTest.kt
+++ b/plugin/src/functionalTest/kotlin/xyz/block/microfilm/MicrofilmPluginFunctionalTest.kt
@@ -23,7 +23,6 @@ import com.autonomousapps.kit.truth.TestKitTruth.Companion.assertThat
 import com.google.common.truth.Truth.assertThat
 import java.io.File
 import org.gradle.testkit.runner.BuildResult
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 
 class MicrofilmPluginFunctionalTest {
@@ -266,7 +265,6 @@ class MicrofilmPluginFunctionalTest {
   }
 
   @Test
-  @Disabled("See https://linear.app/squareup/issue/TCS-698")
   fun `verify task fails when source set has orphaned manifest in microfilm directory`() {
     val project = androidLibProject()
     MANIFEST_FIXTURE.copyToDirectory(directory = project.libMicrofilmDirectory)
@@ -277,7 +275,6 @@ class MicrofilmPluginFunctionalTest {
   }
 
   @Test
-  @Disabled("See https://linear.app/squareup/issue/TCS-698")
   fun `verify task fails when source set has uncompressed png image in resources directory`() {
     val project = androidLibProject()
     PNG_FIXTURE.copyToDirectory(directory = project.libResourcesDrawableDirectory)
@@ -288,7 +285,6 @@ class MicrofilmPluginFunctionalTest {
   }
 
   @Test
-  @Disabled("See https://linear.app/squareup/issue/TCS-698")
   fun `verify task fails when source set has uncompressed png image in microfilm directory`() {
     val project = androidLibProject()
     PNG_FIXTURE.copyToDirectory(directory = project.libMicrofilmDrawableDirectory)

--- a/plugin/src/main/kotlin/xyz/block/microfilm/Files.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/Files.kt
@@ -28,6 +28,12 @@ internal val File.isPngDrawable: Boolean
       !name.endsWith(".9.png", ignoreCase = true) &&
       DRAWABLE_DIRECTORY_PATTERN.matches(input = parentFile.name)
 
+/** True if this is a WebP image in a drawable directory. */
+internal val File.isWebpDrawable: Boolean
+  get() =
+    extension.equals("webp", ignoreCase = true) &&
+      DRAWABLE_DIRECTORY_PATTERN.matches(input = parentFile.name)
+
 /** Produces the SHA256 hash of the given file. */
 fun File.sha256(): String {
   val digest = MessageDigest.getInstance("SHA-256")

--- a/plugin/src/main/kotlin/xyz/block/microfilm/MicrofilmPlugin.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/MicrofilmPlugin.kt
@@ -154,6 +154,9 @@ class MicrofilmPlugin : Plugin<Project> {
         tasks.register("verifyMicrofilm$nameCapitalized", VerifyTask::class.java) { task ->
           task.description = "Verifies that the manifest is up to date for the '$name' source set"
           task.group = "microfilm"
+          task.imageRules.set(extension.imageRules)
+          task.microfilmDirectory.set(microfilmDirectory)
+          task.resourcesDirectory.set(resourcesDirectory)
           task.onlyIf { hasMicrofilmContent() }
         }
 

--- a/plugin/src/main/kotlin/xyz/block/microfilm/VerifyTask.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/VerifyTask.kt
@@ -15,14 +15,147 @@
  */
 package xyz.block.microfilm
 
+import java.io.File
+import kotlinx.serialization.json.Json
 import org.gradle.api.DefaultTask
-import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.GradleException
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
+import xyz.block.microfilm.ImageSettings.Compress
+import xyz.block.microfilm.ImageSettings.Exclude
 
-@CacheableTask
+@DisableCachingByDefault(because = "This task produces no outputs")
 abstract class VerifyTask : DefaultTask() {
+  @get:Internal abstract val imageRules: ListProperty<ImageRule>
+
+  @get:Internal abstract val microfilmDirectory: DirectoryProperty
+
+  @get:Internal abstract val resourcesDirectory: DirectoryProperty
+
+  private val microfilmDirectoryFile by lazy { microfilmDirectory.get().asFile }
+  private val microfilmManifestFile by lazy { File(microfilmDirectoryFile, "manifest.json") }
+  private val resourcesDirectoryFile by lazy { resourcesDirectory.get().asFile }
+
   @TaskAction
   fun verify() {
-    // TODO
+    val failures = mutableListOf<String>()
+
+    // Collect the images in the manifest
+    val manifest =
+      if (microfilmManifestFile.exists()) {
+        JSON.decodeFromString(Manifest.serializer(), microfilmManifestFile.readText())
+      } else {
+        Manifest()
+      }
+    val manifestSourcePaths = manifest.entries.map { entry -> entry.sourcePath }.toSet()
+    val manifestCompressedPaths = manifest.entries.map { entry -> entry.compressedPath }.toSet()
+
+    // Collect the PNG images in the microfilm directory
+    val microfilmPngs = microfilmDirectoryFile.walk().filter { file -> file.isPngDrawable }
+    val microfilmPngPaths =
+      microfilmPngs
+        .map { microfilmPng ->
+          microfilmPng.relativeTo(base = microfilmDirectoryFile).invariantSeparatorsPath
+        }
+        .toSet()
+
+    // Collect the PNG images in the resources directory
+    val resourcesPngs = resourcesDirectoryFile.walk().filter { file -> file.isPngDrawable }
+    val resourcesPngPaths =
+      resourcesPngs
+        .map { resourcesPng ->
+          resourcesPng.relativeTo(base = microfilmDirectoryFile).invariantSeparatorsPath
+        }
+        .toSet()
+
+    // Collect the WebP images in the resources directory
+    val resourcesWebps = resourcesDirectoryFile.walk().filter { file -> file.isWebpDrawable }
+    val resourcesWebpPaths =
+      resourcesWebps
+        .map { resourcesWebp ->
+          resourcesWebp.relativeTo(base = resourcesDirectoryFile).invariantSeparatorsPath
+        }
+        .toSet()
+
+    // Check the microfilm directory for unexpected PNGs
+    failures.addAll(
+      microfilmPngPaths.toSet().subtract(manifestSourcePaths).map { microfilmPngPath ->
+        "Found unexpected PNG image in microfilm directory: $microfilmPngPath"
+      }
+    )
+
+    // Check the microfilm directory for expected PNGs
+    failures.addAll(
+      manifestSourcePaths.subtract(microfilmPngPaths).map { manifestSourcePath ->
+        "Missing expected PNG image in microfilm directory: $manifestSourcePath"
+      }
+    )
+
+    // Check the microfilm PNG SHAs
+    failures.addAll(
+      microfilmPngs
+        .mapNotNull { microfilmPng ->
+          val relativePng = microfilmPng.relativeTo(base = microfilmDirectoryFile)
+          manifest.entries
+            .firstOrNull { entry -> entry.sourcePath == relativePng.invariantSeparatorsPath }
+            ?.let { entry -> microfilmPng to entry }
+        }
+        .filterNot { (microfilmPng, entry) -> microfilmPng.sha256() == entry.sourceSha256 }
+        .map { (_, entry) ->
+          "Incorrect SHA for WebP image in resources directory: ${entry.sourcePath}"
+        }
+    )
+
+    // Check the resources directory for unexpected PNGs
+    failures.addAll(
+      resourcesPngPaths
+        .filter { resourcesPngPath -> resourcesPngPath.resolveImageSettings() is Compress }
+        .map { resourcesPngPath ->
+          "Found unexpected PNG image in resources directory: $resourcesPngPath"
+        }
+    )
+
+    // Check the resources directory for expected WebPs
+    failures.addAll(
+      manifestCompressedPaths.subtract(resourcesWebpPaths).map { manifestCompressedPath ->
+        "Missing expected WebP image in resources directory: $manifestCompressedPath"
+      }
+    )
+
+    // Check the resources WebP SHAs
+    failures.addAll(
+      resourcesWebps
+        .mapNotNull { resourcesWebp ->
+          val relativePng = resourcesWebp.relativeTo(base = resourcesDirectoryFile)
+          manifest.entries
+            .firstOrNull { entry -> entry.compressedPath == relativePng.invariantSeparatorsPath }
+            ?.let { entry -> resourcesWebp to entry }
+        }
+        .filterNot { (resourcesWebp, entry) -> resourcesWebp.sha256() == entry.compressedSha256 }
+        .map { (_, entry) ->
+          "Incorrect SHA for WebP image in resources directory: ${entry.compressedSha256}"
+        }
+    )
+
+    // Report any failures
+    if (failures.isNotEmpty()) {
+      throw GradleException(
+        buildString {
+          appendLine("Microfilm verification failed with ${failures.size} error(s):")
+          failures.forEach { failure -> appendLine("  - $failure") }
+          append("Run ./gradlew compressMicrofilm to update.")
+        }
+      )
+    }
+  }
+
+  private fun String.resolveImageSettings(): ImageSettings =
+    imageRules.get().resolve(imagePath = this)?.imageSettings ?: Exclude
+
+  companion object {
+    private val JSON = Json { ignoreUnknownKeys = true }
   }
 }

--- a/plugin/src/test/kotlin/xyz/block/microfilm/FilesTest.kt
+++ b/plugin/src/test/kotlin/xyz/block/microfilm/FilesTest.kt
@@ -42,4 +42,20 @@ class FilesTest {
   fun `isPngDrawable for png nine-patch`() {
     assertThat(File("src/main/drawable/image.9.png").isPngDrawable).isFalse()
   }
+
+  @Test
+  fun `isWebpDrawable for png drawable`() {
+    assertThat(File("src/main/drawable/image.png").isWebpDrawable).isFalse()
+  }
+
+  @Test
+  fun `isWebpDrawable for webp asset`() {
+    assertThat(File("src/main/asset/image.webp").isWebpDrawable).isFalse()
+  }
+
+  @Test
+  fun `isWebpDrawable for webp drawables`() {
+    assertThat(File("src/main/drawable/image.webp").isWebpDrawable).isTrue()
+    assertThat(File("src/main/drawable-hdpi/image.webp").isWebpDrawable).isTrue()
+  }
 }


### PR DESCRIPTION
Implements the verify task, making sure that:
- There are no PNGs in the resources directory that should be compressed
- There are no PNGs in the microfilm directory that aren't mentioned in the manifest
- All of the PNGs mentioned in the manifest are in the microfilm directory
- All of the WebPs mentioned in the manifest are in the resources directory
- All of the image SHAs match what's in the manifest