### PR TITLE
Rename the `CompressTask` inputs to match `VerifyTask`

### DIFF
--- a/plugin/src/main/kotlin/xyz/block/microfilm/CompressTask.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/CompressTask.kt
@@ -42,11 +42,11 @@ abstract class CompressTask @Inject constructor(private val execOperations: Exec
   @get:PathSensitive(RELATIVE)
   abstract val cwebpDirectory: ConfigurableFileCollection
 
+  @get:Internal abstract val imageRules: ListProperty<ImageRule>
+
   @get:Internal abstract val microfilmDirectory: DirectoryProperty
 
   @get:Internal abstract val resourcesDirectory: DirectoryProperty
-
-  @get:Internal abstract val rules: ListProperty<ImageRule>
 
   private val microfilmDirectoryFile by lazy { microfilmDirectory.get().asFile }
   private val microfilmManifestFile by lazy { File(microfilmDirectoryFile, "manifest.json") }
@@ -169,7 +169,7 @@ abstract class CompressTask @Inject constructor(private val execOperations: Exec
     )
 
   private fun File.resolveImageSettings(): ImageSettings {
-    return rules.get().resolve(imagePath = invariantSeparatorsPath)?.imageSettings ?: Exclude
+    return imageRules.get().resolve(imagePath = invariantSeparatorsPath)?.imageSettings ?: Exclude
   }
 
   companion object {

--- a/plugin/src/main/kotlin/xyz/block/microfilm/MicrofilmPlugin.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/MicrofilmPlugin.kt
@@ -144,9 +144,9 @@ class MicrofilmPlugin : Plugin<Project> {
           task.description = "Compresses source images for the '$name' source set"
           task.group = "microfilm"
           task.cwebpDirectory.from(cwebpDirectory)
+          task.imageRules.set(extension.imageRules)
           task.microfilmDirectory.set(microfilmDirectory)
           task.resourcesDirectory.set(resourcesDirectory)
-          task.rules.set(extension.imageRules)
           task.outputs.upToDateWhen { false }
           task.onlyIf { hasMicrofilmContent() }
         }


### PR DESCRIPTION
Just a tiny bit of clean up, I'm renaming the `rules` input for `CompressTask` to `imageRules` so that it matches the input for `VerifyTask`.