### PR TITLE
Make the public API explicit

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,6 +21,7 @@ ktfmt = "com.facebook:ktfmt:0.62"
 androidApplication = { id = "com.android.application", version.ref = "agp" }
 androidLibrary = { id = "com.android.library", version.ref = "agp" }
 buildconfig = { id = "com.github.gmazzo.buildconfig", version = "6.0.9" }
+kotlinApiDump = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version = "0.18.1" }
 kotlinCompose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlinJvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }

--- a/plugin/api/plugin.api
+++ b/plugin/api/plugin.api
@@ -1,0 +1,43 @@
+public abstract interface class xyz/block/microfilm/ImageSettings {
+}
+
+public final class xyz/block/microfilm/ImageSettings$Compress : xyz/block/microfilm/ImageSettings {
+	public fun <init> (ZLjava/lang/Integer;)V
+	public final fun component1 ()Z
+	public final fun component2 ()Ljava/lang/Integer;
+	public final fun copy (ZLjava/lang/Integer;)Lxyz/block/microfilm/ImageSettings$Compress;
+	public static synthetic fun copy$default (Lxyz/block/microfilm/ImageSettings$Compress;ZLjava/lang/Integer;ILjava/lang/Object;)Lxyz/block/microfilm/ImageSettings$Compress;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCompressionFactor ()Ljava/lang/Integer;
+	public final fun getLossless ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class xyz/block/microfilm/ImageSettings$Compress$Spec {
+	public fun <init> ()V
+	public abstract fun getCompressionFactor ()Lorg/gradle/api/provider/Property;
+	public abstract fun getLossless ()Lorg/gradle/api/provider/Property;
+}
+
+public final class xyz/block/microfilm/ImageSettings$Exclude : xyz/block/microfilm/ImageSettings {
+	public static final field INSTANCE Lxyz/block/microfilm/ImageSettings$Exclude;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class xyz/block/microfilm/MicrofilmExtension {
+	public fun <init> ()V
+	public final fun compress (Ljava/lang/String;Lorg/gradle/api/Action;)V
+	public final fun compress (Lorg/gradle/api/Action;)V
+	public static synthetic fun compress$default (Lxyz/block/microfilm/MicrofilmExtension;Ljava/lang/String;Lorg/gradle/api/Action;ILjava/lang/Object;)V
+	public final fun exclude (Ljava/lang/String;)V
+}
+
+public final class xyz/block/microfilm/MicrofilmPlugin : org/gradle/api/Plugin {
+	public fun <init> ()V
+	public synthetic fun apply (Ljava/lang/Object;)V
+	public fun apply (Lorg/gradle/api/Project;)V
+}
+

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -3,6 +3,7 @@ import com.vanniktech.maven.publish.JavadocJar
 plugins {
   `java-gradle-plugin`
   alias(libs.plugins.buildconfig)
+  alias(libs.plugins.kotlinApiDump)
   alias(libs.plugins.kotlinJvm)
   alias(libs.plugins.kotlinSerialization)
   alias(libs.plugins.mavenPublish)
@@ -17,6 +18,8 @@ gradlePlugin {
     }
   }
 }
+
+kotlin { explicitApi() }
 
 gradleTestKitSupport {
   disablePublication()

--- a/plugin/src/main/kotlin/xyz/block/microfilm/CompressTask.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/CompressTask.kt
@@ -36,8 +36,9 @@ import xyz.block.microfilm.ImageSettings.Compress
 import xyz.block.microfilm.ImageSettings.Exclude
 
 @DisableCachingByDefault(because = "This task modifies the source tree in place")
-abstract class CompressTask @Inject constructor(private val execOperations: ExecOperations) :
-  DefaultTask() {
+internal abstract class CompressTask
+@Inject
+constructor(private val execOperations: ExecOperations) : DefaultTask() {
   @get:InputFiles
   @get:PathSensitive(RELATIVE)
   abstract val cwebpDirectory: ConfigurableFileCollection

--- a/plugin/src/main/kotlin/xyz/block/microfilm/ExtractCwebpBinary.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/ExtractCwebpBinary.kt
@@ -28,7 +28,7 @@ import org.gradle.api.tasks.PathSensitivity.RELATIVE
 
 /** Extracts the cwebp binary from a platform-specific JAR. */
 @CacheableTransform
-abstract class ExtractCwebpBinary : TransformAction<None> {
+internal abstract class ExtractCwebpBinary : TransformAction<None> {
   @get:InputArtifact
   @get:PathSensitive(RELATIVE)
   abstract val inputJar: Provider<FileSystemLocation>

--- a/plugin/src/main/kotlin/xyz/block/microfilm/Files.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/Files.kt
@@ -35,7 +35,7 @@ internal val File.isWebpDrawable: Boolean
       DRAWABLE_DIRECTORY_PATTERN.matches(input = parentFile.name)
 
 /** Produces the SHA256 hash of the given file. */
-fun File.sha256(): String {
+internal fun File.sha256(): String {
   val digest = MessageDigest.getInstance("SHA-256")
   inputStream().use { input ->
     val buffer = ByteArray(8192)

--- a/plugin/src/main/kotlin/xyz/block/microfilm/ImageRule.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/ImageRule.kt
@@ -19,7 +19,7 @@ import java.io.Serializable
 import java.nio.file.FileSystems
 import java.nio.file.Path
 
-data class ImageRule(val pattern: String, val imageSettings: ImageSettings) : Serializable
+internal data class ImageRule(val pattern: String, val imageSettings: ImageSettings) : Serializable
 
 /** Returns true if the [ImageRule] matches the given image. */
 internal fun ImageRule.matches(imagePath: String): Boolean =

--- a/plugin/src/main/kotlin/xyz/block/microfilm/ImageSettings.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/ImageSettings.kt
@@ -17,22 +17,22 @@ package xyz.block.microfilm
 
 import org.gradle.api.provider.Property
 
-sealed interface ImageSettings {
-  data class Compress(val lossless: Boolean, val compressionFactor: Int?) : ImageSettings {
+public sealed interface ImageSettings {
+  public data class Compress(val lossless: Boolean, val compressionFactor: Int?) : ImageSettings {
     init {
       if (compressionFactor != null) {
         require(compressionFactor in 0..100) { "compressionFactor must be between 0 and 100" }
       }
     }
 
-    abstract class Spec {
+    public abstract class Spec {
       /**
        * Specifies whether the WebP compression is lossy or lossless. The default is false.
        *
        * See the cwebp documentation of the -lossless option for more info:
        * https://developers.google.com/speed/webp/docs/cwebp
        */
-      abstract val lossless: Property<Boolean>
+      public abstract val lossless: Property<Boolean>
 
       /**
        * Specify the compression factor for RGB channels between 0 and 100. The default is 75.
@@ -47,7 +47,7 @@ sealed interface ImageSettings {
        * See the cwebp documentation of the -q option for more info:
        * https://developers.google.com/speed/webp/docs/cwebp
        */
-      abstract val compressionFactor: Property<Int>
+      public abstract val compressionFactor: Property<Int>
 
       init {
         lossless.convention(false)
@@ -58,5 +58,5 @@ sealed interface ImageSettings {
     }
   }
 
-  data object Exclude : ImageSettings
+  public data object Exclude : ImageSettings
 }

--- a/plugin/src/main/kotlin/xyz/block/microfilm/Manifest.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/Manifest.kt
@@ -18,7 +18,7 @@ package xyz.block.microfilm
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class Manifest(val entries: List<Entry> = emptyList()) {
+internal data class Manifest(val entries: List<Entry> = emptyList()) {
   @Serializable
   data class Entry(
     val sourcePath: String,

--- a/plugin/src/main/kotlin/xyz/block/microfilm/MicrofilmExtension.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/MicrofilmExtension.kt
@@ -22,7 +22,7 @@ import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.ProviderFactory
 import xyz.block.microfilm.ImageSettings.Exclude
 
-abstract class MicrofilmExtension {
+public abstract class MicrofilmExtension {
   @get:Inject internal abstract val objects: ObjectFactory
   @get:Inject internal abstract val providers: ProviderFactory
 
@@ -30,7 +30,7 @@ abstract class MicrofilmExtension {
 
   /** Compresses the images matching the given glob [pattern]. Matches all images by default. */
   @JvmOverloads
-  fun compress(pattern: String = "**", action: Action<ImageSettings.Compress.Spec>) {
+  public fun compress(pattern: String = "**", action: Action<ImageSettings.Compress.Spec>) {
     val spec = objects.newInstance(ImageSettings.Compress.Spec::class.java)
     action.execute(spec)
     imageRules.add(
@@ -39,7 +39,7 @@ abstract class MicrofilmExtension {
   }
 
   /** Excludes the images matching the given glob [pattern]. */
-  fun exclude(pattern: String) {
+  public fun exclude(pattern: String) {
     imageRules.add(providers.provider { ImageRule(pattern = pattern, imageSettings = Exclude) })
   }
 }

--- a/plugin/src/main/kotlin/xyz/block/microfilm/MicrofilmPlugin.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/MicrofilmPlugin.kt
@@ -33,7 +33,7 @@ import org.gradle.nativeplatform.OperatingSystemFamily.LINUX
 import org.gradle.nativeplatform.OperatingSystemFamily.MACOS
 import org.gradle.nativeplatform.OperatingSystemFamily.OPERATING_SYSTEM_ATTRIBUTE
 
-class MicrofilmPlugin : Plugin<Project> {
+public class MicrofilmPlugin : Plugin<Project> {
   override fun apply(target: Project): Unit = target.run {
     // Configure the extension
     val extension = extensions.create("microfilm", MicrofilmExtension::class.java)
@@ -166,7 +166,7 @@ class MicrofilmPlugin : Plugin<Project> {
     }
   }
 
-  companion object {
+  private companion object {
     private const val CWEBP_BINARY_TYPE = "cwebp-binary"
     private const val PLUGIN_ID_APPLICATION = "com.android.application"
     private const val PLUGIN_ID_LIBRARY = "com.android.library"

--- a/plugin/src/main/kotlin/xyz/block/microfilm/VerifyTask.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/VerifyTask.kt
@@ -28,7 +28,7 @@ import xyz.block.microfilm.ImageSettings.Compress
 import xyz.block.microfilm.ImageSettings.Exclude
 
 @DisableCachingByDefault(because = "This task produces no outputs")
-abstract class VerifyTask : DefaultTask() {
+internal abstract class VerifyTask : DefaultTask() {
   @get:Internal abstract val imageRules: ListProperty<ImageRule>
 
   @get:Internal abstract val microfilmDirectory: DirectoryProperty


### PR DESCRIPTION
I'm doing two things to make our public API explicit:
- Enabling `explicitApi`. This means that we have to explicitly mark everything as `public`/`internal`/`private`. It'll help us be more deliberate about what we expose, which should really just the plugin DSL.
- Adding the binary compatibility validator plugin. This dumps our public API to a file and fails the build if it changes unexpectedly. I don't expect this to be a major issue, but it's still nice.