### PR TITLE
Disable explicit nulls for JSON serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,7 @@ The resulting manifest file will look something like this:
       "compressor": {
         "name": "cwebp",
         "version": "1.6.0",
-        "lossless": true,
-        "compressionFactor": null
+        "lossless": true
       }
     }
   ]

--- a/plugin/src/functionalTest/resources/manifest.json
+++ b/plugin/src/functionalTest/resources/manifest.json
@@ -8,8 +8,7 @@
       "compressor": {
         "name": "cwebp",
         "version": "1.6.0",
-        "lossless": true,
-        "compressionFactor": null
+        "lossless": true
       }
     }
   ]

--- a/plugin/src/functionalTest/resources/manifest_full.json
+++ b/plugin/src/functionalTest/resources/manifest_full.json
@@ -8,8 +8,7 @@
       "compressor": {
         "name": "cwebp",
         "version": "1.6.0",
-        "lossless": true,
-        "compressionFactor": null
+        "lossless": true
       }
     },
     {

--- a/plugin/src/main/kotlin/xyz/block/microfilm/CompressTask.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/CompressTask.kt
@@ -179,6 +179,7 @@ constructor(private val execOperations: ExecOperations) : DefaultTask() {
     @OptIn(ExperimentalSerializationApi::class)
     private val JSON = Json {
       encodeDefaults = true
+      explicitNulls = false
       prettyPrint = true
       prettyPrintIndent = "  "
     }

--- a/plugin/src/main/kotlin/xyz/block/microfilm/VerifyTask.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/VerifyTask.kt
@@ -156,6 +156,9 @@ internal abstract class VerifyTask : DefaultTask() {
     imageRules.get().resolve(imagePath = this)?.imageSettings ?: Exclude
 
   companion object {
-    private val JSON = Json { ignoreUnknownKeys = true }
+    private val JSON = Json {
+      explicitNulls = false
+      ignoreUnknownKeys = true
+    }
   }
 }

--- a/sample/app/src/main/microfilm/manifest.json
+++ b/sample/app/src/main/microfilm/manifest.json
@@ -8,8 +8,7 @@
       "compressor": {
         "name": "cwebp",
         "version": "1.6.0",
-        "lossless": true,
-        "compressionFactor": null
+        "lossless": true
       }
     },
     {
@@ -32,8 +31,7 @@
       "compressor": {
         "name": "cwebp",
         "version": "1.6.0",
-        "lossless": true,
-        "compressionFactor": null
+        "lossless": true
       }
     },
     {
@@ -56,8 +54,7 @@
       "compressor": {
         "name": "cwebp",
         "version": "1.6.0",
-        "lossless": true,
-        "compressionFactor": null
+        "lossless": true
       }
     },
     {
@@ -80,8 +77,7 @@
       "compressor": {
         "name": "cwebp",
         "version": "1.6.0",
-        "lossless": true,
-        "compressionFactor": null
+        "lossless": true
       }
     },
     {
@@ -104,8 +100,7 @@
       "compressor": {
         "name": "cwebp",
         "version": "1.6.0",
-        "lossless": true,
-        "compressionFactor": null
+        "lossless": true
       }
     },
     {

--- a/sample/library/src/main/microfilm/manifest.json
+++ b/sample/library/src/main/microfilm/manifest.json
@@ -8,8 +8,7 @@
       "compressor": {
         "name": "cwebp",
         "version": "1.6.0",
-        "lossless": true,
-        "compressionFactor": null
+        "lossless": true
       }
     },
     {
@@ -32,8 +31,7 @@
       "compressor": {
         "name": "cwebp",
         "version": "1.6.0",
-        "lossless": true,
-        "compressionFactor": null
+        "lossless": true
       }
     },
     {
@@ -56,8 +54,7 @@
       "compressor": {
         "name": "cwebp",
         "version": "1.6.0",
-        "lossless": true,
-        "compressionFactor": null
+        "lossless": true
       }
     },
     {
@@ -80,8 +77,7 @@
       "compressor": {
         "name": "cwebp",
         "version": "1.6.0",
-        "lossless": true,
-        "compressionFactor": null
+        "lossless": true
       }
     },
     {
@@ -104,8 +100,7 @@
       "compressor": {
         "name": "cwebp",
         "version": "1.6.0",
-        "lossless": true,
-        "compressionFactor": null
+        "lossless": true
       }
     },
     {


### PR DESCRIPTION
Right now we require explicit nulls for every field in the metadata, both when serializing and when parsing. That introduces a lot of churn when we introduce new optional metadata fields, forcing us to regenerate every manifest. It also adds a lot of noise to the manifest and hides the settings that we actually used.

I don't think that's necessary, so I'm disabling explicit nulls. I think that will give us better forward/backwards compatibility when I add new optional parameters in the next two PRs.