### PR TITLE
Make the metadata configurable

### DIFF
--- a/plugin/api/plugin.api
+++ b/plugin/api/plugin.api
@@ -1,15 +1,34 @@
+public final class xyz/block/microfilm/ImageMetadata {
+	public static final field Companion Lxyz/block/microfilm/ImageMetadata$Companion;
+	public fun <init> ()V
+	public fun <init> (ZZZ)V
+	public synthetic fun <init> (ZZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getExif ()Z
+	public final fun getIcc ()Z
+	public final fun getXmp ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class xyz/block/microfilm/ImageMetadata$Companion {
+	public final fun getNone ()Lxyz/block/microfilm/ImageMetadata;
+}
+
 public abstract interface class xyz/block/microfilm/ImageSettings {
 }
 
 public final class xyz/block/microfilm/ImageSettings$Compress : xyz/block/microfilm/ImageSettings {
-	public fun <init> (ZLjava/lang/Integer;)V
+	public fun <init> ()V
+	public fun <init> (ZLjava/lang/Integer;Lxyz/block/microfilm/ImageMetadata;)V
+	public synthetic fun <init> (ZLjava/lang/Integer;Lxyz/block/microfilm/ImageMetadata;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Z
 	public final fun component2 ()Ljava/lang/Integer;
-	public final fun copy (ZLjava/lang/Integer;)Lxyz/block/microfilm/ImageSettings$Compress;
-	public static synthetic fun copy$default (Lxyz/block/microfilm/ImageSettings$Compress;ZLjava/lang/Integer;ILjava/lang/Object;)Lxyz/block/microfilm/ImageSettings$Compress;
+	public final fun component3 ()Lxyz/block/microfilm/ImageMetadata;
+	public final fun copy (ZLjava/lang/Integer;Lxyz/block/microfilm/ImageMetadata;)Lxyz/block/microfilm/ImageSettings$Compress;
+	public static synthetic fun copy$default (Lxyz/block/microfilm/ImageSettings$Compress;ZLjava/lang/Integer;Lxyz/block/microfilm/ImageMetadata;ILjava/lang/Object;)Lxyz/block/microfilm/ImageSettings$Compress;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCompressionFactor ()Ljava/lang/Integer;
 	public final fun getLossless ()Z
+	public final fun getMetadata ()Lxyz/block/microfilm/ImageMetadata;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -18,6 +37,7 @@ public abstract class xyz/block/microfilm/ImageSettings$Compress$Spec {
 	public fun <init> ()V
 	public abstract fun getCompressionFactor ()Lorg/gradle/api/provider/Property;
 	public abstract fun getLossless ()Lorg/gradle/api/provider/Property;
+	public abstract fun getMetadata ()Lorg/gradle/api/provider/Property;
 }
 
 public final class xyz/block/microfilm/ImageSettings$Exclude : xyz/block/microfilm/ImageSettings {

--- a/plugin/src/main/kotlin/xyz/block/microfilm/Cwebp.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/Cwebp.kt
@@ -53,6 +53,11 @@ internal class Cwebp(
             add(compressionFactor.toString())
           }
 
+          imageSettings.metadata?.let { metadata ->
+            add("-metadata")
+            add(metadata.toString())
+          }
+
           add("-o")
           add(destinationWebp.absolutePath)
           add(sourcePng.absolutePath)

--- a/plugin/src/main/kotlin/xyz/block/microfilm/ImageMetadata.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/ImageMetadata.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2026 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package xyz.block.microfilm
+
+/**
+ * Metadata that can be copied from the source image to the compressed image if present.
+ *
+ * See the cwebp documentation of the -metadata option for more info:
+ * https://developers.google.com/speed/webp/docs/cwebp
+ */
+public class ImageMetadata(
+  public val exif: Boolean = false,
+  public val icc: Boolean = false,
+  public val xmp: Boolean = false,
+) {
+  override fun toString(): String =
+    when {
+      exif && icc && xmp -> "all"
+      !exif && !icc && !xmp -> "none"
+      else ->
+        buildList {
+            if (exif) add("exif")
+            if (icc) add("icc")
+            if (xmp) add("xmp")
+          }
+          .joinToString(separator = ",")
+    }
+
+  public companion object {
+    /** The default value that copies no metadata from the source image to the compressed image. */
+    public val None: ImageMetadata = ImageMetadata()
+  }
+}

--- a/plugin/src/main/kotlin/xyz/block/microfilm/ImageSettings.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/ImageSettings.kt
@@ -18,7 +18,11 @@ package xyz.block.microfilm
 import org.gradle.api.provider.Property
 
 public sealed interface ImageSettings {
-  public data class Compress(val lossless: Boolean, val compressionFactor: Int?) : ImageSettings {
+  public data class Compress(
+    val lossless: Boolean = false,
+    val compressionFactor: Int? = null,
+    val metadata: ImageMetadata? = null,
+  ) : ImageSettings {
     init {
       if (compressionFactor != null) {
         require(compressionFactor in 0..100) { "compressionFactor must be between 0 and 100" }
@@ -35,7 +39,7 @@ public sealed interface ImageSettings {
       public abstract val lossless: Property<Boolean>
 
       /**
-       * Specify the compression factor for RGB channels between 0 and 100. The default is 75.
+       * Specifies the compression factor for RGB channels between 0 and 100. The default is 75.
        *
        * In case of lossy compression (default), a small factor produces a smaller file with lower
        * quality. Best quality is achieved by using a value of 100.
@@ -49,12 +53,25 @@ public sealed interface ImageSettings {
        */
       public abstract val compressionFactor: Property<Int>
 
+      /**
+       * Specifies the metadata to copy from the source image to the compressed image if present.
+       * The default is none.
+       *
+       * See the cwebp documentation of the -metadata option for more info:
+       * https://developers.google.com/speed/webp/docs/cwebp
+       */
+      public abstract val metadata: Property<ImageMetadata>
+
       init {
         lossless.convention(false)
       }
 
       internal fun resolve(): Compress =
-        Compress(lossless = lossless.get(), compressionFactor = compressionFactor.orNull)
+        Compress(
+          lossless = lossless.get(),
+          compressionFactor = compressionFactor.orNull,
+          metadata = metadata.orNull,
+        )
     }
   }
 

--- a/plugin/src/main/kotlin/xyz/block/microfilm/Manifest.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/Manifest.kt
@@ -35,6 +35,7 @@ internal data class Manifest(val entries: List<Entry> = emptyList()) {
     val version: String,
     val lossless: Boolean,
     val compressionFactor: Int?,
+    val metadata: String?,
   )
 }
 
@@ -44,4 +45,5 @@ internal fun ImageSettings.Compress.toCompressor(cwebpVersion: String) =
     version = cwebpVersion,
     lossless = lossless,
     compressionFactor = compressionFactor,
+    metadata = metadata?.toString(),
   )

--- a/plugin/src/test/kotlin/xyz/block/microfilm/ImageMetadataTest.kt
+++ b/plugin/src/test/kotlin/xyz/block/microfilm/ImageMetadataTest.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2026 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package xyz.block.microfilm
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import org.junit.jupiter.api.Test
+
+class ImageMetadataTest {
+  @Test
+  fun `toString produces expected options`() {
+    assertThat(ImageMetadata(exif = false, icc = false, xmp = false).toString()).isEqualTo("none")
+    assertThat(ImageMetadata(exif = false, icc = false, xmp = true).toString()).isEqualTo("xmp")
+    assertThat(ImageMetadata(exif = false, icc = true, xmp = false).toString()).isEqualTo("icc")
+    assertThat(ImageMetadata(exif = false, icc = true, xmp = true).toString()).isEqualTo("icc,xmp")
+    assertThat(ImageMetadata(exif = true, icc = false, xmp = false).toString()).isEqualTo("exif")
+    assertThat(ImageMetadata(exif = true, icc = false, xmp = true).toString()).isEqualTo("exif,xmp")
+    assertThat(ImageMetadata(exif = true, icc = true, xmp = false).toString()).isEqualTo("exif,icc")
+    assertThat(ImageMetadata(exif = true, icc = true, xmp = true).toString()).isEqualTo("all")
+  }
+}


### PR DESCRIPTION
Right now we're applying the `-metadata icc` option to every image. I did that because one of the original images I used had an embedded ICC color profile, and compressing without it changed how the image looked. I don't think that's a common situation, at least in `cash-android`, so I'm making it optional.