### PR TITLE
Move the cwebp operations into a utility class

### DIFF
--- a/plugin/src/main/kotlin/xyz/block/microfilm/CompressTask.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/CompressTask.kt
@@ -15,7 +15,6 @@
  */
 package xyz.block.microfilm
 
-import java.io.ByteArrayOutputStream
 import java.io.File
 import javax.inject.Inject
 import kotlin.text.RegexOption.IGNORE_CASE
@@ -49,6 +48,7 @@ constructor(private val execOperations: ExecOperations) : DefaultTask() {
 
   @get:Internal abstract val resourcesDirectory: DirectoryProperty
 
+  private val cwebp by lazy { Cwebp(execOperations = execOperations, directory = cwebpDirectory) }
   private val microfilmDirectoryFile by lazy { microfilmDirectory.get().asFile }
   private val microfilmManifestFile by lazy { File(microfilmDirectoryFile, "manifest.json") }
   private val resourcesDirectoryFile by lazy { resourcesDirectory.get().asFile }
@@ -74,7 +74,7 @@ constructor(private val execOperations: ExecOperations) : DefaultTask() {
     val microfilmPngs = microfilmDirectoryFile.walk().filter { file -> file.isPngDrawable }.toList()
 
     // Compress the microfilm PNGs to WebP in the resources directory
-    val cwebpExecutable = cwebpDirectory.singleFile.resolve("cwebp")
+    val cwebpVersion = cwebp.getVersion()
     microfilmPngs
       .mapNotNull { microfilmPng ->
         val imageSettings =
@@ -84,34 +84,12 @@ constructor(private val execOperations: ExecOperations) : DefaultTask() {
       .forEach { (microfilmPng, imageSettings) ->
         val resourcesWebp = microfilmPngToResourcesWebp(microfilmPng = microfilmPng)
         resourcesWebp.parentFile?.mkdirs()
-        execOperations.exec { action ->
-          action.commandLine(
-            buildList {
-              add(cwebpExecutable.absolutePath)
-              add("-metadata")
-              add("icc")
-              if (imageSettings.lossless) {
-                add("-lossless")
-              }
-              imageSettings.compressionFactor?.let { compressionFactor ->
-                add("-q")
-                add(compressionFactor.toString())
-              }
-              add("-o")
-              add(resourcesWebp.absolutePath)
-              add(microfilmPng.absolutePath)
-            }
-          )
-        }
+        cwebp.compress(
+          imageSettings = imageSettings,
+          sourcePng = microfilmPng,
+          destinationWebp = resourcesWebp,
+        )
       }
-
-    // Get the current cwebp version
-    val output = ByteArrayOutputStream()
-    execOperations.exec { action ->
-      action.commandLine(cwebpExecutable.absolutePath, "-version")
-      action.standardOutput = output
-    }
-    val cwebpVersion = output.toString().lines().first().trim()
 
     // Create the manifest
     val manifest =
@@ -133,13 +111,7 @@ constructor(private val execOperations: ExecOperations) : DefaultTask() {
                 compressedPath =
                   resourcesWebp.relativeTo(base = resourcesDirectoryFile).invariantSeparatorsPath,
                 compressedSha256 = resourcesWebp.sha256(),
-                compressor =
-                  Manifest.Compressor(
-                    name = "cwebp",
-                    version = cwebpVersion,
-                    lossless = imageSettings.lossless,
-                    compressionFactor = imageSettings.compressionFactor,
-                  ),
+                compressor = imageSettings.toCompressor(cwebpVersion = cwebpVersion),
               )
             }
       )

--- a/plugin/src/main/kotlin/xyz/block/microfilm/Cwebp.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/Cwebp.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2026 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package xyz.block.microfilm
+
+import java.io.ByteArrayOutputStream
+import java.io.File
+import kotlin.io.resolve
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.process.ExecOperations
+
+/** A wrapper around the cwebp executable. */
+internal class Cwebp(
+  private val execOperations: ExecOperations,
+  private val directory: ConfigurableFileCollection,
+) {
+  private val executable by lazy { directory.singleFile.resolve("cwebp") }
+
+  /** Returns the current cweb version. */
+  fun getVersion(): String {
+    val output = ByteArrayOutputStream()
+    execOperations.exec { action ->
+      action.commandLine(executable.absolutePath, "-version")
+      action.standardOutput = output
+    }
+    return output.toString().lines().first().trim()
+  }
+
+  /** Compresses the source PNG image to the destination WebP using the given settings. */
+  fun compress(imageSettings: ImageSettings.Compress, sourcePng: File, destinationWebp: File) {
+    execOperations.exec { action ->
+      action.commandLine(
+        buildList {
+          add(executable.absolutePath)
+          if (imageSettings.lossless) {
+            add("-lossless")
+          }
+
+          imageSettings.compressionFactor?.let { compressionFactor ->
+            add("-q")
+            add(compressionFactor.toString())
+          }
+
+          add("-o")
+          add(destinationWebp.absolutePath)
+          add(sourcePng.absolutePath)
+        }
+      )
+    }
+  }
+}

--- a/plugin/src/main/kotlin/xyz/block/microfilm/Manifest.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/Manifest.kt
@@ -16,6 +16,7 @@
 package xyz.block.microfilm
 
 import kotlinx.serialization.Serializable
+import xyz.block.microfilm.Manifest.Compressor
 
 @Serializable
 internal data class Manifest(val entries: List<Entry> = emptyList()) {
@@ -36,3 +37,11 @@ internal data class Manifest(val entries: List<Entry> = emptyList()) {
     val compressionFactor: Int?,
   )
 }
+
+internal fun ImageSettings.Compress.toCompressor(cwebpVersion: String) =
+  Compressor(
+    name = "cwebp",
+    version = cwebpVersion,
+    lossless = lossless,
+    compressionFactor = compressionFactor,
+  )


### PR DESCRIPTION
Currently the operations to get the version and compress images are hardcoded in `CompressTask`. In the next PR I'm going to retrieve the version in `VerifyTask` as part of verifying the compression settings, so I'm moving things to a shared `Cwebp` utility.