### PR TITLE
Move `Cwebp` behind an interface and use Okio paths

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@ agp = "9.2.1"
 cwebp = "1.6.0"
 kotlin = "2.4.10"
 mavenPublish = "0.37.0"
+okio = "3.17.0"
 testkit = "0.19"
 
 [libraries]
@@ -16,6 +17,8 @@ junit-jupiter = { module = "org.junit.jupiter:junit-jupiter" }
 junit-launcher = { module = "org.junit.platform:junit-platform-launcher" }
 kotlinx-serialization-json = "org.jetbrains.kotlinx:kotlinx-serialization-json:1.11.0"
 ktfmt = "com.facebook:ktfmt:0.64"
+okio = { module = "com.squareup.okio:okio", version.ref = "okio" }
+okio-fakeFileSystem = { module = "com.squareup.okio:okio-fakefilesystem", version.ref = "okio" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -37,10 +37,12 @@ dependencies {
   compileOnly(libs.agp)
 
   implementation(libs.kotlinx.serialization.json)
+  implementation(libs.okio)
 
   testImplementation(libs.assertk)
   testImplementation(platform(libs.junit.bom))
   testImplementation(libs.junit.jupiter)
+  testImplementation(libs.okio.fakeFileSystem)
   testRuntimeOnly(libs.junit.launcher)
 
   functionalTestImplementation(platform(libs.junit.bom))

--- a/plugin/src/main/kotlin/xyz/block/microfilm/CompressTask.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/CompressTask.kt
@@ -20,6 +20,7 @@ import javax.inject.Inject
 import kotlin.text.RegexOption.IGNORE_CASE
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
+import okio.Path.Companion.toOkioPath
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
@@ -33,6 +34,7 @@ import org.gradle.process.ExecOperations
 import org.gradle.work.DisableCachingByDefault
 import xyz.block.microfilm.ImageSettings.Compress
 import xyz.block.microfilm.ImageSettings.Exclude
+import xyz.block.microfilm.cwebp.RealCwebp
 
 @DisableCachingByDefault(because = "This task modifies the source tree in place")
 internal abstract class CompressTask
@@ -48,13 +50,14 @@ constructor(private val execOperations: ExecOperations) : DefaultTask() {
 
   @get:Internal abstract val resourcesDirectory: DirectoryProperty
 
-  private val cwebp by lazy { Cwebp(execOperations = execOperations, directory = cwebpDirectory) }
   private val microfilmDirectoryFile by lazy { microfilmDirectory.get().asFile }
   private val microfilmManifestFile by lazy { File(microfilmDirectoryFile, "manifest.json") }
   private val resourcesDirectoryFile by lazy { resourcesDirectory.get().asFile }
 
   @TaskAction
   fun compress() {
+    val cwebp = RealCwebp(execOperations = execOperations, directory = cwebpDirectory)
+
     // Find the resources PNGs
     val resourcesPngs = resourcesDirectoryFile.walk().filter { file -> file.isPngDrawable }.toList()
 
@@ -86,8 +89,8 @@ constructor(private val execOperations: ExecOperations) : DefaultTask() {
         resourcesWebp.parentFile?.mkdirs()
         cwebp.compress(
           imageSettings = imageSettings,
-          sourcePng = microfilmPng,
-          destinationWebp = resourcesWebp,
+          sourcePng = microfilmPng.toOkioPath(),
+          destinationWebp = resourcesWebp.toOkioPath(),
         )
       }
 

--- a/plugin/src/main/kotlin/xyz/block/microfilm/MicrofilmPlugin.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/MicrofilmPlugin.kt
@@ -32,6 +32,7 @@ import org.gradle.nativeplatform.OperatingSystemFamily
 import org.gradle.nativeplatform.OperatingSystemFamily.LINUX
 import org.gradle.nativeplatform.OperatingSystemFamily.MACOS
 import org.gradle.nativeplatform.OperatingSystemFamily.OPERATING_SYSTEM_ATTRIBUTE
+import xyz.block.microfilm.cwebp.ExtractCwebpBinary
 
 public class MicrofilmPlugin : Plugin<Project> {
   override fun apply(target: Project): Unit = target.run {

--- a/plugin/src/main/kotlin/xyz/block/microfilm/VerifyTask.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/VerifyTask.kt
@@ -32,6 +32,7 @@ import org.gradle.process.ExecOperations
 import org.gradle.work.DisableCachingByDefault
 import xyz.block.microfilm.ImageSettings.Compress
 import xyz.block.microfilm.ImageSettings.Exclude
+import xyz.block.microfilm.cwebp.RealCwebp
 
 @DisableCachingByDefault(because = "This task produces no outputs")
 internal abstract class VerifyTask @Inject constructor(private val execOperations: ExecOperations) :
@@ -46,13 +47,13 @@ internal abstract class VerifyTask @Inject constructor(private val execOperation
 
   @get:Internal abstract val resourcesDirectory: DirectoryProperty
 
-  private val cwebp by lazy { Cwebp(execOperations = execOperations, directory = cwebpDirectory) }
   private val microfilmDirectoryFile by lazy { microfilmDirectory.get().asFile }
   private val microfilmManifestFile by lazy { File(microfilmDirectoryFile, "manifest.json") }
   private val resourcesDirectoryFile by lazy { resourcesDirectory.get().asFile }
 
   @TaskAction
   fun verify() {
+    val cwebp = RealCwebp(execOperations = execOperations, directory = cwebpDirectory)
     val failures = mutableListOf<String>()
 
     // Collect the images in the manifest

--- a/plugin/src/main/kotlin/xyz/block/microfilm/cwebp/Cwebp.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/cwebp/Cwebp.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2026 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package xyz.block.microfilm.cwebp
+
+import okio.Path
+import xyz.block.microfilm.ImageSettings.Compress
+
+/** A wrapper around the cwebp executable. */
+internal interface Cwebp {
+  /** Returns the current cwebp version. */
+  fun getVersion(): String
+
+  /** Compresses the source PNG image to the destination WebP using the given settings. */
+  fun compress(imageSettings: Compress, sourcePng: Path, destinationWebp: Path)
+}

--- a/plugin/src/main/kotlin/xyz/block/microfilm/cwebp/ExtractCwebpBinary.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/cwebp/ExtractCwebpBinary.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package xyz.block.microfilm
+package xyz.block.microfilm.cwebp
 
 import java.util.zip.ZipInputStream
 import org.gradle.api.artifacts.transform.CacheableTransform

--- a/plugin/src/main/kotlin/xyz/block/microfilm/cwebp/RealCwebp.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/cwebp/RealCwebp.kt
@@ -13,33 +13,33 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package xyz.block.microfilm
+package xyz.block.microfilm.cwebp
 
 import java.io.ByteArrayOutputStream
-import java.io.File
 import kotlin.io.resolve
+import okio.Path
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.process.ExecOperations
+import xyz.block.microfilm.ImageSettings.Compress
 
-/** A wrapper around the cwebp executable. */
-internal class Cwebp(
+/** A [Cwebp] backed by [ExecOperations] and a cwebp binary executable. */
+internal class RealCwebp(
   private val execOperations: ExecOperations,
   private val directory: ConfigurableFileCollection,
-) {
+) : Cwebp {
   private val executable by lazy { directory.singleFile.resolve("cwebp") }
-
-  /** Returns the current cweb version. */
-  fun getVersion(): String {
+  private val _version by lazy {
     val output = ByteArrayOutputStream()
     execOperations.exec { action ->
       action.commandLine(executable.absolutePath, "-version")
       action.standardOutput = output
     }
-    return output.toString().lines().first().trim()
+    output.toString().lines().first().trim()
   }
 
-  /** Compresses the source PNG image to the destination WebP using the given settings. */
-  fun compress(imageSettings: ImageSettings.Compress, sourcePng: File, destinationWebp: File) {
+  override fun getVersion(): String = _version
+
+  override fun compress(imageSettings: Compress, sourcePng: Path, destinationWebp: Path) {
     execOperations.exec { action ->
       action.commandLine(
         buildList {
@@ -64,8 +64,8 @@ internal class Cwebp(
           }
 
           add("-o")
-          add(destinationWebp.absolutePath)
-          add(sourcePng.absolutePath)
+          add(destinationWebp.toString())
+          add(sourcePng.toString())
         }
       )
     }

--- a/plugin/src/test/kotlin/xyz/block/microfilm/cwebp/FakeCwebp.kt
+++ b/plugin/src/test/kotlin/xyz/block/microfilm/cwebp/FakeCwebp.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2026 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package xyz.block.microfilm.cwebp
+
+import okio.ByteString.Companion.encodeUtf8
+import okio.Path
+import okio.fakefilesystem.FakeFileSystem
+import xyz.block.microfilm.ImageSettings.Compress
+
+class FakeCwebp(
+  private val fileSystem: FakeFileSystem,
+  private val convertToWebp: (pngContent: String) -> String,
+) : Cwebp {
+  val compressions = ArrayDeque<Pair<Path, Path>>()
+
+  override fun getVersion(): String = VERSION
+
+  override fun compress(imageSettings: Compress, sourcePng: Path, destinationWebp: Path) {
+    compressions.add(sourcePng to destinationWebp)
+    val pngContent = fileSystem.read(file = sourcePng) { readUtf8() }
+    val webpContent = convertToWebp(pngContent)
+    fileSystem.write(file = destinationWebp) { write(webpContent.encodeUtf8()) }
+  }
+
+  companion object {
+    const val VERSION = "1.2.3"
+  }
+}


### PR DESCRIPTION
## Context
There's a lot of business logic in the Gradle task classes right now. It works, and it's covered in part by our functional tests, but it's a little hard to reason about and unit test.

I want to refactor our approach in a couple ways:
- Move logic out of the Gradle tasks so that it's easier to break down and test
- Use Okio's `FileSystem` instead of regular Java `File`s so that it's easy to fake the disk state in unit tests
- Share file system scanning logic across the compress and verify tasks 
- Introduce the concept of an `ImageGroup` so that it's easy to reason about the compression or verification of a single conceptual image in isolation

## This PR
Makes `Cwebp` into an interface with real and fake implementations, and updates its API to accept Okio `Path`s instead of `File`s.