### PR TITLE
Introduce a `Scanner` that searches the file system for `ImageGroup`s

### DIFF
--- a/plugin/src/main/kotlin/xyz/block/microfilm/FileSystems.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/FileSystems.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2026 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package xyz.block.microfilm
+
+import okio.FileSystem
+import okio.Path
+
+/**
+ * Returns the results of [listRecursively] if the given directory exists, or an empty sequence if
+ * it does not.
+ */
+internal fun FileSystem.listRecursivelyOrEmpty(dir: Path): Sequence<Path> =
+  if (metadataOrNull(path = dir)?.isDirectory == true) {
+    listRecursively(dir = dir)
+  } else {
+    emptySequence()
+  }

--- a/plugin/src/main/kotlin/xyz/block/microfilm/Paths.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/Paths.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2026 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package xyz.block.microfilm
+
+import okio.Path
+
+/** Matches Android drawable resource directories like `drawable` and `drawable-hdpi`. */
+private val DRAWABLE_DIRECTORY_PATTERN = Regex(pattern = "^drawable(-.*)?$")
+
+/** True if this is a file in a drawable directory. */
+internal val Path.isInDrawableDirectory
+  get() = parent?.name?.matches(regex = DRAWABLE_DIRECTORY_PATTERN) == true
+
+/**
+ * True if this is a PNG image in a drawable directory.
+ *
+ * Excludes nine-patch (`.9.png`) images because Android treats them differently than regular PNGs
+ * and they cannot be converted to any other image format.
+ */
+internal val Path.isPngDrawable
+  get() =
+    name.endsWith(suffix = ".png", ignoreCase = true) &&
+      !name.endsWith(suffix = ".9.png", ignoreCase = true) &&
+      isInDrawableDirectory
+
+/** True if this is a WebP image in a drawable directory. */
+internal val Path.isWebpDrawable
+  get() = isInDrawableDirectory && name.endsWith(suffix = ".webp", ignoreCase = true)

--- a/plugin/src/main/kotlin/xyz/block/microfilm/scanning/ImageGroup.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/scanning/ImageGroup.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2026 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package xyz.block.microfilm.scanning
+
+import okio.Path
+import xyz.block.microfilm.Manifest
+
+/**
+ * The group of files for a single conceptual image resource, and the associated manifest entry.
+ *
+ * The key is the image's path relative to the `res` or `microfilm` directory, without the file
+ * extension. So for example, these three files would all share the key `drawable-hdpi/image`:
+ * - `src/main/res/drawable-hdpi/image.png`
+ * - `src/main/res/drawable-hdpi/image.webp`
+ * - `src/main/microfilm/drawable-hdpi/image.png`
+ */
+internal data class ImageGroup(
+  val key: String,
+  val resourcesPng: Path?,
+  val resourcesWebp: Path?,
+  val microfilmPng: Path?,
+  val microfilmManifestEntry: Manifest.Entry?,
+)

--- a/plugin/src/main/kotlin/xyz/block/microfilm/scanning/RealScanner.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/scanning/RealScanner.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2026 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package xyz.block.microfilm.scanning
+
+import kotlinx.serialization.json.Json
+import okio.FileSystem
+import okio.Path
+import okio.Path.Companion.toPath
+import xyz.block.microfilm.Manifest
+import xyz.block.microfilm.isPngDrawable
+import xyz.block.microfilm.isWebpDrawable
+import xyz.block.microfilm.listRecursivelyOrEmpty
+
+/** A [Scanner] backed by an Okio [FileSystem]. */
+internal class RealScanner(
+  private val fileSystem: FileSystem,
+  private val resourcesDirectory: Path,
+  private val microfilmDirectory: Path,
+) : Scanner {
+  override fun scan(): List<ImageGroup> {
+    // Read the png and webp images
+    val resourcesPngs =
+      fileSystem
+        .listRecursivelyOrEmpty(dir = resourcesDirectory)
+        .filter { path -> path.isPngDrawable }
+        .filter { path -> fileSystem.metadata(path = path).isRegularFile }
+        .associateBy { path -> path.relativeTo(other = resourcesDirectory).key }
+    val resourcesWebps =
+      fileSystem
+        .listRecursivelyOrEmpty(dir = resourcesDirectory)
+        .filter { path -> path.isWebpDrawable }
+        .filter { path -> fileSystem.metadata(path = path).isRegularFile }
+        .associateBy { path -> path.relativeTo(other = resourcesDirectory).key }
+    val microfilmPngs =
+      fileSystem
+        .listRecursivelyOrEmpty(dir = microfilmDirectory)
+        .filter { path -> path.isPngDrawable }
+        .filter { path -> fileSystem.metadata(path = path).isRegularFile }
+        .associateBy { path -> path.relativeTo(other = microfilmDirectory).key }
+
+    // Read the manifest entries
+    val microfilmManifestPath = microfilmDirectory.resolve("manifest.json")
+    val microfilmManifestEntries =
+      if (fileSystem.exists(path = microfilmManifestPath)) {
+        fileSystem
+          .read(file = microfilmManifestPath) { readUtf8() }
+          .let<String, Manifest> { string -> JSON.decodeFromString(string = string) }
+          .entries
+          .associateBy { entry -> entry.sourcePath.toPath().key }
+      } else {
+        emptyMap()
+      }
+
+    // Group the images for each unique key
+    return buildSet {
+      addAll(resourcesPngs.keys)
+      addAll(resourcesWebps.keys)
+      addAll(microfilmPngs.keys)
+      addAll(microfilmManifestEntries.keys)
+    }
+      .toList()
+      .sorted()
+      .map { key ->
+        ImageGroup(
+          key = key,
+          resourcesPng = resourcesPngs[key],
+          resourcesWebp = resourcesWebps[key],
+          microfilmPng = microfilmPngs[key],
+          microfilmManifestEntry = microfilmManifestEntries[key],
+        )
+      }
+  }
+}
+
+private val JSON = Json {
+  explicitNulls = false
+  ignoreUnknownKeys = true
+}
+
+private val Path.key
+  get() = buildList {
+    addAll(segments.dropLast(n = 1))
+    add(name.substringBeforeLast(delimiter = "."))
+  }
+    .joinToString(separator = "/")

--- a/plugin/src/main/kotlin/xyz/block/microfilm/scanning/Scanner.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/scanning/Scanner.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2026 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package xyz.block.microfilm.scanning
+
+/**
+ * A scanner that locates image files on disk and groups them by key.
+ *
+ * The key is the image's path relative to the `res` or `microfilm` directory, without the file
+ * extension. So for example, these three files would all share the key `drawable-hdpi/image`:
+ * - `src/main/res/drawable-hdpi/image.png`
+ * - `src/main/res/drawable-hdpi/image.webp`
+ * - `src/main/microfilm/drawable-hdpi/image.png`
+ */
+internal interface Scanner {
+  /** Returns a list of images on disk grouped by key. */
+  fun scan(): List<ImageGroup>
+}

--- a/plugin/src/test/kotlin/xyz/block/microfilm/FileSystemsTest.kt
+++ b/plugin/src/test/kotlin/xyz/block/microfilm/FileSystemsTest.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2026 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package xyz.block.microfilm
+
+import assertk.assertThat
+import assertk.assertions.containsExactly
+import assertk.assertions.isEmpty
+import okio.ByteString.Companion.encodeUtf8
+import okio.Path.Companion.toPath
+import okio.fakefilesystem.FakeFileSystem
+import org.junit.jupiter.api.Test
+import xyz.block.microfilm.ImageGroupFixtures.PNG_CONTENT
+import xyz.block.microfilm.ImageGroupFixtures.WEBP_CONTENT
+
+class FileSystemsTest {
+  val fileSystem =
+    FakeFileSystem().apply {
+      createDirectories(dir = DRAWABLE_DIRECTORY)
+      write(file = PNG_IMAGE) { write(PNG_CONTENT.encodeUtf8()) }
+      write(file = WEBP_IMAGE) { write(WEBP_CONTENT.encodeUtf8()) }
+    }
+
+  @Test
+  fun `listRecursivelyOrEmpty returns files for directory that exists`() {
+    assertThat(fileSystem.listRecursivelyOrEmpty(dir = RES_DIRECTORY))
+      .containsExactly(DRAWABLE_DIRECTORY, PNG_IMAGE, WEBP_IMAGE)
+  }
+
+  @Test
+  fun `listRecursivelyOrEmpty returns nothing for directory that does not exist`() {
+    assertThat(fileSystem.listRecursivelyOrEmpty(dir = "src/main/other".toPath())).isEmpty()
+  }
+
+  @Test
+  fun `listRecursivelyOrEmpty returns nothing for regular file`() {
+    assertThat(fileSystem.listRecursivelyOrEmpty(dir = PNG_IMAGE)).isEmpty()
+  }
+
+  companion object {
+    private val RES_DIRECTORY = "src/main/res".toPath()
+    private val DRAWABLE_DIRECTORY = RES_DIRECTORY.resolve(child = "drawable")
+    private val PNG_IMAGE = DRAWABLE_DIRECTORY.resolve(child = "image.png")
+    private val WEBP_IMAGE = DRAWABLE_DIRECTORY.resolve(child = "image.webp")
+  }
+}

--- a/plugin/src/test/kotlin/xyz/block/microfilm/ImageGroupFixtures.kt
+++ b/plugin/src/test/kotlin/xyz/block/microfilm/ImageGroupFixtures.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2026 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package xyz.block.microfilm
+
+import okio.Path.Companion.toPath
+import xyz.block.microfilm.ImageSettings.Compress
+import xyz.block.microfilm.cwebp.FakeCwebp
+import xyz.block.microfilm.scanning.ImageGroup
+
+internal object ImageGroupFixtures {
+  const val KEY = "drawable/photo"
+  const val RELATIVE_PNG = "$KEY.png"
+  const val RELATIVE_WEBP = "$KEY.webp"
+
+  val PROJECT_DIRECTORY = "/project/src/main".toPath()
+  val RESOURCES_DIRECTORY = PROJECT_DIRECTORY.resolve(child = "res")
+  val MICROFILM_DIRECTORY = PROJECT_DIRECTORY.resolve(child = "microfilm")
+
+  val RESOURCES_PNG = RESOURCES_DIRECTORY.resolve(child = RELATIVE_PNG)
+  val RESOURCES_WEBP = RESOURCES_DIRECTORY.resolve(child = RELATIVE_WEBP)
+  val MICROFILM_PNG = MICROFILM_DIRECTORY.resolve(child = RELATIVE_PNG)
+
+  const val PNG_CONTENT = "png"
+  const val PNG_HASH = "8f8cbb7dcf46e0bc7d53265749a6c17d116093a6ba95e442764060c76fd4a86c"
+  const val WEBP_CONTENT = "webp"
+  const val WEBP_HASH = "a57bb082e728a0cdce930ecfcccf4510a3a247be5f322b09b3a971a3f5ed34f8"
+
+  val LOSSY_COMPRESS = Compress(lossless = false)
+  val LOSSLESS_COMPRESS = Compress(lossless = true)
+
+  val LOSSY_MANIFEST_ENTRY =
+    Manifest.Entry(
+      sourcePath = RELATIVE_PNG,
+      sourceSha256 = PNG_HASH,
+      compressedPath = RELATIVE_WEBP,
+      compressedSha256 = WEBP_HASH,
+      compressor = LOSSY_COMPRESS.toCompressor(cwebpVersion = FakeCwebp.VERSION),
+    )
+  val LOSSLESS_MANIFEST_ENTRY =
+    Manifest.Entry(
+      sourcePath = RELATIVE_PNG,
+      sourceSha256 = PNG_HASH,
+      compressedPath = RELATIVE_WEBP,
+      compressedSha256 = WEBP_HASH,
+      compressor = LOSSLESS_COMPRESS.toCompressor(cwebpVersion = FakeCwebp.VERSION),
+    )
+
+  val EMPTY_IMAGE_GROUP =
+    ImageGroup(
+      key = KEY,
+      resourcesPng = null,
+      resourcesWebp = null,
+      microfilmPng = null,
+      microfilmManifestEntry = null,
+    )
+  val LOSSY_IMAGE_GROUP =
+    ImageGroup(
+      key = KEY,
+      resourcesPng = null,
+      resourcesWebp = RESOURCES_WEBP,
+      microfilmPng = MICROFILM_PNG,
+      microfilmManifestEntry = LOSSY_MANIFEST_ENTRY,
+    )
+  val LOSSLESS_IMAGE_GROUP =
+    ImageGroup(
+      key = KEY,
+      resourcesPng = null,
+      resourcesWebp = RESOURCES_WEBP,
+      microfilmPng = MICROFILM_PNG,
+      microfilmManifestEntry = LOSSLESS_MANIFEST_ENTRY,
+    )
+}

--- a/plugin/src/test/kotlin/xyz/block/microfilm/PathsTest.kt
+++ b/plugin/src/test/kotlin/xyz/block/microfilm/PathsTest.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2026 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package xyz.block.microfilm
+
+import assertk.assertThat
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
+import okio.Path.Companion.toPath
+import org.junit.jupiter.api.Test
+
+class PathsTest {
+  @Test
+  fun `isInDrawableDirectory is true for file in unqualified drawable directory`() {
+    assertThat("src/main/res/drawable/image.png".toPath().isInDrawableDirectory).isTrue()
+  }
+
+  @Test
+  fun `isInDrawableDirectory is true for file in qualified drawable directories`() {
+    assertThat("src/main/res/drawable-anydpi/image.png".toPath().isInDrawableDirectory).isTrue()
+    assertThat("src/main/res/drawable-nodpi/image.png".toPath().isInDrawableDirectory).isTrue()
+    assertThat("src/main/res/drawable-ldpi/image.png".toPath().isInDrawableDirectory).isTrue()
+    assertThat("src/main/res/drawable-mdpi/image.png".toPath().isInDrawableDirectory).isTrue()
+    assertThat("src/main/res/drawable-hdpi/image.png".toPath().isInDrawableDirectory).isTrue()
+    assertThat("src/main/res/drawable-xhdpi/image.png".toPath().isInDrawableDirectory).isTrue()
+    assertThat("src/main/res/drawable-xxhdpi/image.png".toPath().isInDrawableDirectory).isTrue()
+    assertThat("src/main/res/drawable-xxxhdpi/image.png".toPath().isInDrawableDirectory).isTrue()
+    assertThat("src/main/res/drawable-night/image.png".toPath().isInDrawableDirectory).isTrue()
+    assertThat("src/main/res/drawable-v24/image.png".toPath().isInDrawableDirectory).isTrue()
+    assertThat("src/main/res/drawable-land/image.png".toPath().isInDrawableDirectory).isTrue()
+  }
+
+  @Test
+  fun `isInDrawableDirectory is false for file in other directory`() {
+    assertThat("src/main/res/assets/image.png".toPath().isInDrawableDirectory).isFalse()
+  }
+
+  @Test
+  fun `isPngDrawable is true for png in drawable directory`() {
+    assertThat("src/main/res/drawable/image.png".toPath().isPngDrawable).isTrue()
+    assertThat("src/main/res/drawable/IMAGE.PNG".toPath().isPngDrawable).isTrue()
+  }
+
+  @Test
+  fun `isPngDrawable is false for png in other directory`() {
+    assertThat("src/main/res/assets/image.png".toPath().isPngDrawable).isFalse()
+  }
+
+  @Test
+  fun `isPngDrawable is false for nine-patch in drawable directory`() {
+    assertThat("src/main/res/drawable/image.9.png".toPath().isPngDrawable).isFalse()
+  }
+
+  @Test
+  fun `isPngDrawable is false for webp in drawable directory`() {
+    assertThat("src/main/res/drawable/image.webp".toPath().isPngDrawable).isFalse()
+  }
+
+  @Test
+  fun `isPngDrawable is false for directory in drawable directory`() {
+    assertThat("src/main/res/drawable/nested".toPath().isPngDrawable).isFalse()
+  }
+
+  @Test
+  fun `isWebpDrawable is true for webp in drawable directory`() {
+    assertThat("src/main/res/drawable/image.webp".toPath().isWebpDrawable).isTrue()
+    assertThat("src/main/res/drawable/IMAGE.WEBP".toPath().isWebpDrawable).isTrue()
+  }
+
+  @Test
+  fun `isWebpDrawable is false for webp in other directory`() {
+    assertThat("src/main/res/assets/image.webp".toPath().isWebpDrawable).isFalse()
+  }
+
+  @Test
+  fun `isWebpDrawable is false for png in drawable directory`() {
+    assertThat("src/main/res/drawable/image.png".toPath().isWebpDrawable).isFalse()
+  }
+
+  @Test
+  fun `isWebpDrawable is false for directory in drawable directory`() {
+    assertThat("src/main/res/drawable/nested".toPath().isWebpDrawable).isFalse()
+  }
+}

--- a/plugin/src/test/kotlin/xyz/block/microfilm/scanning/FakeScanner.kt
+++ b/plugin/src/test/kotlin/xyz/block/microfilm/scanning/FakeScanner.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2026 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package xyz.block.microfilm.scanning
+
+internal class FakeScanner : Scanner {
+  val scanRequests = ArrayDeque<Unit>()
+  val scanResponses = ArrayDeque<List<ImageGroup>>()
+
+  override fun scan(): List<ImageGroup> {
+    scanRequests.add(Unit)
+    return scanResponses.firstOrNull() ?: emptyList()
+  }
+}

--- a/plugin/src/test/kotlin/xyz/block/microfilm/scanning/RealScannerTest.kt
+++ b/plugin/src/test/kotlin/xyz/block/microfilm/scanning/RealScannerTest.kt
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2026 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package xyz.block.microfilm.scanning
+
+import assertk.assertThat
+import assertk.assertions.containsExactly
+import assertk.assertions.isEmpty
+import kotlinx.serialization.json.Json
+import okio.ByteString.Companion.encodeUtf8
+import okio.fakefilesystem.FakeFileSystem
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import xyz.block.microfilm.ImageGroupFixtures.EMPTY_IMAGE_GROUP
+import xyz.block.microfilm.ImageGroupFixtures.KEY
+import xyz.block.microfilm.ImageGroupFixtures.LOSSY_MANIFEST_ENTRY
+import xyz.block.microfilm.ImageGroupFixtures.MICROFILM_DIRECTORY
+import xyz.block.microfilm.ImageGroupFixtures.MICROFILM_PNG
+import xyz.block.microfilm.ImageGroupFixtures.PNG_CONTENT
+import xyz.block.microfilm.ImageGroupFixtures.RESOURCES_DIRECTORY
+import xyz.block.microfilm.ImageGroupFixtures.RESOURCES_PNG
+import xyz.block.microfilm.ImageGroupFixtures.RESOURCES_WEBP
+import xyz.block.microfilm.ImageGroupFixtures.WEBP_CONTENT
+import xyz.block.microfilm.Manifest
+
+class RealScannerTest {
+  private val fileSystem =
+    FakeFileSystem().apply {
+      createDirectories(dir = RESOURCES_PNG.parent!!)
+      createDirectories(dir = MICROFILM_PNG.parent!!)
+    }
+
+  private val scanner =
+    RealScanner(
+      fileSystem = fileSystem,
+      resourcesDirectory = RESOURCES_DIRECTORY,
+      microfilmDirectory = MICROFILM_DIRECTORY,
+    )
+
+  @AfterEach
+  fun tearDown() {
+    fileSystem.checkNoOpenFiles()
+  }
+
+  @Test
+  fun `scan finds nothing when empty`() {
+    fileSystem.deleteRecursively(fileOrDirectory = RESOURCES_PNG.parent!!)
+    fileSystem.deleteRecursively(fileOrDirectory = MICROFILM_PNG.parent!!)
+
+    assertThat(scanner.scan()).isEmpty()
+  }
+
+  @Test
+  fun `scan finds a resources png`() {
+    fileSystem.write(file = RESOURCES_PNG) { write(PNG_CONTENT.encodeUtf8()) }
+
+    assertThat(scanner.scan()).containsExactly(EMPTY_IMAGE_GROUP.copy(resourcesPng = RESOURCES_PNG))
+  }
+
+  @Test
+  fun `scan finds a resources webp`() {
+    fileSystem.write(file = RESOURCES_WEBP) { write(WEBP_CONTENT.encodeUtf8()) }
+
+    assertThat(scanner.scan())
+      .containsExactly(EMPTY_IMAGE_GROUP.copy(resourcesWebp = RESOURCES_WEBP))
+  }
+
+  @Test
+  fun `scan finds a microfilm png`() {
+    fileSystem.write(file = MICROFILM_PNG) { write(PNG_CONTENT.encodeUtf8()) }
+
+    assertThat(scanner.scan()).containsExactly(EMPTY_IMAGE_GROUP.copy(microfilmPng = MICROFILM_PNG))
+  }
+
+  @Test
+  fun `scan finds a manifest entry`() {
+    writeManifest(LOSSY_MANIFEST_ENTRY)
+
+    assertThat(scanner.scan())
+      .containsExactly(EMPTY_IMAGE_GROUP.copy(microfilmManifestEntry = LOSSY_MANIFEST_ENTRY))
+  }
+
+  @Test
+  fun `scan groups items with the same key`() {
+    fileSystem.write(file = RESOURCES_PNG) { write(PNG_CONTENT.encodeUtf8()) }
+    fileSystem.write(file = RESOURCES_WEBP) { write(WEBP_CONTENT.encodeUtf8()) }
+    fileSystem.write(file = MICROFILM_PNG) { write(PNG_CONTENT.encodeUtf8()) }
+    writeManifest(LOSSY_MANIFEST_ENTRY)
+
+    assertThat(scanner.scan())
+      .containsExactly(
+        ImageGroup(
+          key = KEY,
+          resourcesPng = RESOURCES_PNG,
+          resourcesWebp = RESOURCES_WEBP,
+          microfilmPng = MICROFILM_PNG,
+          microfilmManifestEntry = LOSSY_MANIFEST_ENTRY,
+        )
+      )
+  }
+
+  private fun writeManifest(vararg entries: Manifest.Entry) {
+    fileSystem.write(file = MICROFILM_DIRECTORY.resolve(child = "manifest.json")) {
+      writeUtf8(
+        Json.encodeToString(
+          serializer = Manifest.serializer(),
+          value = Manifest(entries = entries.toList()),
+        )
+      )
+    }
+  }
+}


### PR DESCRIPTION
## Context
There's a lot of business logic in the Gradle task classes right now. It works, and it's covered in part by our functional tests, but it's a little hard to reason about and unit test.

I want to refactor our approach in a couple ways:
- Move logic out of the Gradle tasks so that it's easier to break down and test
- Use Okio's `FileSystem` instead of regular Java `File`s so that it's easy to fake the disk state in unit tests
- Share file system scanning logic across the compress and verify tasks 
- Introduce the concept of an `ImageGroup` so that it's easy to reason about the compression or verification of a single conceptual image in isolation

## This PR
Introduces a new `ImageGroup` model and a scanner that looks for groups of images on the file system.

An `ImageGroup` consists of:
- An optional resources png file
- An optional resources webp file
- An optional microfilm png file
- An optional microfilm manifest entry

That model, combined with an `ImageSettings` matched from the Gradle configuration, is enough to compress or verify a single image in isolation, so I'll be integrating this stuff with the existing tasks later in the stack.