### PR TITLE
Add an `Unspecified` case to `ImageSettings`

### DIFF
--- a/plugin/api/plugin.api
+++ b/plugin/api/plugin.api
@@ -50,6 +50,13 @@ public final class xyz/block/microfilm/ImageSettings$Exclude : xyz/block/microfi
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class xyz/block/microfilm/ImageSettings$Unspecified : xyz/block/microfilm/ImageSettings {
+	public static final field INSTANCE Lxyz/block/microfilm/ImageSettings$Unspecified;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public abstract class xyz/block/microfilm/MicrofilmExtension {
 	public fun <init> ()V
 	public final fun compress (Ljava/lang/String;Lorg/gradle/api/Action;)V

--- a/plugin/src/main/kotlin/xyz/block/microfilm/ImageSettings.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/ImageSettings.kt
@@ -18,6 +18,7 @@ package xyz.block.microfilm
 import org.gradle.api.provider.Property
 
 public sealed interface ImageSettings {
+  /** The settings for images that are targeted by a compress rule in the Gradle configuration. */
   public data class Compress(
     val lossless: Boolean = false,
     val compressionFactor: Int? = null,
@@ -89,5 +90,12 @@ public sealed interface ImageSettings {
     }
   }
 
+  /** The settings for images that are targeted by an exclude rule in the Gradle configuration. */
   public data object Exclude : ImageSettings
+
+  /**
+   * The settings for images that are not targeted by neither a compress nor an exclude rule in the
+   * Gradle configuration.
+   */
+  public data object Unspecified : ImageSettings
 }

--- a/plugin/src/main/kotlin/xyz/block/microfilm/VerifyTask.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/VerifyTask.kt
@@ -32,6 +32,7 @@ import org.gradle.process.ExecOperations
 import org.gradle.work.DisableCachingByDefault
 import xyz.block.microfilm.ImageSettings.Compress
 import xyz.block.microfilm.ImageSettings.Exclude
+import xyz.block.microfilm.ImageSettings.Unspecified
 import xyz.block.microfilm.cwebp.RealCwebp
 
 @DisableCachingByDefault(because = "This task produces no outputs")
@@ -162,7 +163,8 @@ internal abstract class VerifyTask @Inject constructor(private val execOperation
           when (imageSettings) {
             is Compress ->
               entry.compressor != imageSettings.toCompressor(cwebpVersion = cwebpVersion)
-            is Exclude -> true
+            is Exclude,
+            is Unspecified -> true
           }
         }
         .map { (entry, _) ->


### PR DESCRIPTION
## Context
There's a lot of business logic in the Gradle task classes right now. It works, and it's covered in part by our functional tests, but it's a little hard to reason about and unit test.

I want to refactor our approach in a couple ways:
- Move logic out of the Gradle tasks so that it's easier to break down and test
- Use Okio's `FileSystem` instead of regular Java `File`s so that it's easy to fake the disk state in unit tests
- Share file system scanning logic across the compress and verify tasks 
- Introduce the concept of an `ImageGroup` so that it's easy to reason about the compression or verification of a single conceptual image in isolation

## This PR
One thing that's unclear in the current implementation is what happens to images that aren't targeted by a `compress` or an `exclude` rule in the Gradle configuration. I'm adding a new `ImageSettings` subtype to model that case explicitly, and I'll use it in later PRs to report errors when the settings for an image are unspecified.