### PR TITLE
Add a `Compressor` interface and an implementation that delegates based on the image settings type

### DIFF
--- a/plugin/src/main/kotlin/xyz/block/microfilm/compression/Compressor.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/compression/Compressor.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2026 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package xyz.block.microfilm.compression
+
+import xyz.block.microfilm.ImageSettings
+import xyz.block.microfilm.Manifest
+import xyz.block.microfilm.scanning.ImageGroup
+
+/**
+ * A compressor that compresses images according to the image settings declared in the Gradle
+ * configuration.
+ */
+internal interface Compressor<T : ImageSettings> {
+  /** Compresses the given image using the given settings. */
+  fun compress(imageGroup: ImageGroup, imageSettings: T): Result
+
+  sealed interface Result {
+    /**
+     * Returned when an image was successfully compressed, with a manifest entry that matches the
+     * current state. If the image is excluded, the manifest entry is null.
+     */
+    data class Success(val microfilmManifestEntry: Manifest.Entry?) : Result
+
+    /** Returned when an image could not be compressed for some reason. */
+    sealed interface Failure : Result {
+      val description: String
+    }
+  }
+}

--- a/plugin/src/main/kotlin/xyz/block/microfilm/compression/TypedCompressor.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/compression/TypedCompressor.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2026 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package xyz.block.microfilm.compression
+
+import xyz.block.microfilm.ImageSettings
+import xyz.block.microfilm.ImageSettings.Compress
+import xyz.block.microfilm.ImageSettings.Exclude
+import xyz.block.microfilm.ImageSettings.Unspecified
+import xyz.block.microfilm.compression.Compressor.Result
+import xyz.block.microfilm.scanning.ImageGroup
+
+internal class TypedCompressor(
+  private val compressCompressor: Compressor<Compress>,
+  private val excludeCompressor: Compressor<Exclude>,
+  private val unspecifiedCompressor: Compressor<Unspecified>,
+) : Compressor<ImageSettings> {
+  override fun compress(imageGroup: ImageGroup, imageSettings: ImageSettings): Result {
+    return when (imageSettings) {
+      is Compress ->
+        compressCompressor.compress(imageGroup = imageGroup, imageSettings = imageSettings)
+
+      is Exclude ->
+        excludeCompressor.compress(imageGroup = imageGroup, imageSettings = imageSettings)
+
+      is Unspecified ->
+        unspecifiedCompressor.compress(imageGroup = imageGroup, imageSettings = imageSettings)
+    }
+  }
+}

--- a/plugin/src/test/kotlin/xyz/block/microfilm/compression/FakeCompressor.kt
+++ b/plugin/src/test/kotlin/xyz/block/microfilm/compression/FakeCompressor.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2026 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package xyz.block.microfilm.compression
+
+import xyz.block.microfilm.ImageSettings
+import xyz.block.microfilm.compression.Compressor.Result
+import xyz.block.microfilm.compression.Compressor.Result.Success
+import xyz.block.microfilm.scanning.ImageGroup
+
+internal class FakeCompressor<T : ImageSettings> : Compressor<T> {
+  val compressRequests = ArrayDeque<Pair<ImageGroup, ImageSettings>>()
+  val compressResults = ArrayDeque<Result>()
+
+  override fun compress(imageGroup: ImageGroup, imageSettings: T): Result {
+    compressRequests.add(imageGroup to imageSettings)
+    return compressResults.removeFirstOrNull() ?: Success(microfilmManifestEntry = null)
+  }
+}

--- a/plugin/src/test/kotlin/xyz/block/microfilm/compression/TypedCompressorTest.kt
+++ b/plugin/src/test/kotlin/xyz/block/microfilm/compression/TypedCompressorTest.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2026 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package xyz.block.microfilm.compression
+
+import assertk.assertThat
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import org.junit.jupiter.api.Test
+import xyz.block.microfilm.ImageGroupFixtures.LOSSY_COMPRESS
+import xyz.block.microfilm.ImageGroupFixtures.LOSSY_IMAGE_GROUP
+import xyz.block.microfilm.ImageSettings.Compress
+import xyz.block.microfilm.ImageSettings.Exclude
+import xyz.block.microfilm.ImageSettings.Unspecified
+
+class TypedCompressorTest {
+  private val compressCompressor = FakeCompressor<Compress>()
+  private val excludeCompressor = FakeCompressor<Exclude>()
+  private val unspecifiedCompressor = FakeCompressor<Unspecified>()
+
+  private val compressor =
+    TypedCompressor(
+      compressCompressor = compressCompressor,
+      excludeCompressor = excludeCompressor,
+      unspecifiedCompressor = unspecifiedCompressor,
+    )
+
+  @Test
+  fun `compress delegates to compress compressor`() {
+    compressor.compress(imageGroup = LOSSY_IMAGE_GROUP, imageSettings = LOSSY_COMPRESS)
+
+    assertThat(compressCompressor.compressRequests.first())
+      .isEqualTo(LOSSY_IMAGE_GROUP to LOSSY_COMPRESS)
+    assertThat(excludeCompressor.compressRequests).isEmpty()
+    assertThat(unspecifiedCompressor.compressRequests).isEmpty()
+  }
+
+  @Test
+  fun `compress delegates to exclude compressor`() {
+    compressor.compress(imageGroup = LOSSY_IMAGE_GROUP, imageSettings = Exclude)
+
+    assertThat(compressCompressor.compressRequests).isEmpty()
+    assertThat(excludeCompressor.compressRequests.first()).isEqualTo(LOSSY_IMAGE_GROUP to Exclude)
+    assertThat(unspecifiedCompressor.compressRequests).isEmpty()
+  }
+
+  @Test
+  fun `compress delegates to unspecified compressor`() {
+    compressor.compress(imageGroup = LOSSY_IMAGE_GROUP, imageSettings = Unspecified)
+
+    assertThat(compressCompressor.compressRequests).isEmpty()
+    assertThat(excludeCompressor.compressRequests).isEmpty()
+    assertThat(unspecifiedCompressor.compressRequests.first())
+      .isEqualTo(LOSSY_IMAGE_GROUP to Unspecified)
+  }
+}


### PR DESCRIPTION
## Context
There's a lot of business logic in the Gradle task classes right now. It works, and it's covered in part by our functional tests, but it's a little hard to reason about and unit test.

I want to refactor our approach in a couple ways:
- Move logic out of the Gradle tasks so that it's easier to break down and test
- Use Okio's `FileSystem` instead of regular Java `File`s so that it's easy to fake the disk state in unit tests
- Share file system scanning logic across the compress and verify tasks 
- Introduce the concept of an `ImageGroup` so that it's easy to reason about the compression or verification of a single conceptual image in isolation

## This PR
Introduces a new `Compressor` interface that we'll use to implement `CompressTask`.

Ultimately this interface will have a couple implementations:
- `CompressCompressor`: handles images targeted by a `compress` rule (by actually compressing them)
- `ExcludeCompressor`: handles images targeted by an `exclude` rule (by deleting any microfilm metadata)
- `UnspecifiedCompressor`: handles images not targeted by any rule (by reporting an error)
- `TypedCompressor`: a small utility that delegates to each of the three compressors above by type