### PR TITLE
Add a `Compressor` that handles images targeted by a `compress` rule

### DIFF
--- a/plugin/src/main/kotlin/xyz/block/microfilm/FileSystems.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/FileSystems.kt
@@ -17,6 +17,7 @@ package xyz.block.microfilm
 
 import okio.FileSystem
 import okio.Path
+import okio.buffer
 
 /**
  * Returns the results of [listRecursively] if the given directory exists, or an empty sequence if
@@ -28,3 +29,7 @@ internal fun FileSystem.listRecursivelyOrEmpty(dir: Path): Sequence<Path> =
   } else {
     emptySequence()
   }
+
+/** Returns the SHA256 hash of the file at the given path. */
+internal fun FileSystem.sha256(file: Path) =
+  source(file = file).buffer().use { source -> source.readByteString().sha256().hex() }

--- a/plugin/src/main/kotlin/xyz/block/microfilm/Paths.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/Paths.kt
@@ -15,7 +15,9 @@
  */
 package xyz.block.microfilm
 
+import kotlin.text.RegexOption.IGNORE_CASE
 import okio.Path
+import okio.Path.Companion.toPath
 
 /** Matches Android drawable resource directories like `drawable` and `drawable-hdpi`. */
 private val DRAWABLE_DIRECTORY_PATTERN = Regex(pattern = "^drawable(-.*)?$")
@@ -39,3 +41,9 @@ internal val Path.isPngDrawable
 /** True if this is a WebP image in a drawable directory. */
 internal val Path.isWebpDrawable
   get() = isInDrawableDirectory && name.endsWith(suffix = ".webp", ignoreCase = true)
+
+/** Returns a new path with the new file extension instead of the old one. */
+internal fun Path.replaceExtension(old: String, new: String) =
+  toString()
+    .replace(regex = Regex(pattern = "\\.$old$", option = IGNORE_CASE), replacement = ".$new")
+    .toPath()

--- a/plugin/src/main/kotlin/xyz/block/microfilm/compression/CompressCompressor.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/compression/CompressCompressor.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2026 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package xyz.block.microfilm.compression
+
+import okio.FileSystem
+import okio.Path
+import xyz.block.microfilm.ImageSettings.Compress
+import xyz.block.microfilm.Manifest.Entry
+import xyz.block.microfilm.compression.Compressor.Result
+import xyz.block.microfilm.compression.Compressor.Result.Success
+import xyz.block.microfilm.cwebp.Cwebp
+import xyz.block.microfilm.replaceExtension
+import xyz.block.microfilm.scanning.ImageGroup
+import xyz.block.microfilm.sha256
+import xyz.block.microfilm.toCompressor
+
+/** A [Compressor] that handles image groups covered by [Compress] image settings. */
+internal class CompressCompressor(
+  private val cwebp: Cwebp,
+  private val fileSystem: FileSystem,
+  private val resourcesDirectory: Path,
+  private val microfilmDirectory: Path,
+) : Compressor<Compress> {
+  override fun compress(imageGroup: ImageGroup, imageSettings: Compress): Result {
+    val cwebpVersion = cwebp.getVersion()
+    val resourcesPng = imageGroup.resourcesPng
+    var resourcesWebp = imageGroup.resourcesWebp
+    var microfilmPng = imageGroup.microfilmPng
+    val microfilmManifestEntry = imageGroup.microfilmManifestEntry
+
+    // If there's a resources png, move it to the microfilm directory
+    resourcesPng?.let {
+      val relativePng = resourcesPng.relativeTo(other = resourcesDirectory)
+      microfilmPng = microfilmDirectory.resolve(child = relativePng)
+      microfilmPng.parent?.let { parent -> fileSystem.createDirectories(dir = parent) }
+      fileSystem.atomicMove(source = resourcesPng, target = microfilmPng)
+    }
+
+    // If there is no microfilm png source image, return an empty microfilm manifest entry
+    if (microfilmPng == null) {
+      resourcesWebp?.let { fileSystem.delete(path = resourcesWebp) }
+      return Success(microfilmManifestEntry = null)
+    }
+
+    // If the image has already been compressed, return the current microfilm manifest entry
+    if (
+      resourcesWebp != null &&
+        microfilmManifestEntry != null &&
+        fileSystem.exists(path = microfilmPng) &&
+        fileSystem.exists(path = resourcesWebp) &&
+        fileSystem.sha256(file = microfilmPng) == microfilmManifestEntry.sourceSha256 &&
+        fileSystem.sha256(file = resourcesWebp) == microfilmManifestEntry.compressedSha256 &&
+        imageSettings.toCompressor(cwebpVersion = cwebpVersion) == microfilmManifestEntry.compressor
+    ) {
+      return Success(microfilmManifestEntry = microfilmManifestEntry)
+    }
+
+    // Compress the image
+    val relativePng = microfilmPng.relativeTo(other = microfilmDirectory)
+    val relativeWebp = relativePng.replaceExtension(old = "png", new = "webp")
+    resourcesWebp = resourcesDirectory.resolve(child = relativeWebp)
+    resourcesWebp.parent?.let { parent -> fileSystem.createDirectories(dir = parent) }
+    cwebp.compress(
+      imageSettings = imageSettings,
+      sourcePng = microfilmPng,
+      destinationWebp = resourcesWebp,
+    )
+
+    // Return a new microfilm manifest entry
+    return Success(
+      microfilmManifestEntry =
+        Entry(
+          sourcePath = microfilmPng.relativeTo(other = microfilmDirectory).toString(),
+          sourceSha256 = fileSystem.sha256(file = microfilmPng),
+          compressedPath = resourcesWebp.relativeTo(other = resourcesDirectory).toString(),
+          compressedSha256 = fileSystem.sha256(file = resourcesWebp),
+          compressor = imageSettings.toCompressor(cwebpVersion = cwebpVersion),
+        )
+    )
+  }
+}

--- a/plugin/src/test/kotlin/xyz/block/microfilm/FileSystemsTest.kt
+++ b/plugin/src/test/kotlin/xyz/block/microfilm/FileSystemsTest.kt
@@ -18,11 +18,13 @@ package xyz.block.microfilm
 import assertk.assertThat
 import assertk.assertions.containsExactly
 import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
 import okio.ByteString.Companion.encodeUtf8
 import okio.Path.Companion.toPath
 import okio.fakefilesystem.FakeFileSystem
 import org.junit.jupiter.api.Test
 import xyz.block.microfilm.ImageGroupFixtures.PNG_CONTENT
+import xyz.block.microfilm.ImageGroupFixtures.PNG_HASH
 import xyz.block.microfilm.ImageGroupFixtures.WEBP_CONTENT
 
 class FileSystemsTest {
@@ -47,6 +49,11 @@ class FileSystemsTest {
   @Test
   fun `listRecursivelyOrEmpty returns nothing for regular file`() {
     assertThat(fileSystem.listRecursivelyOrEmpty(dir = PNG_IMAGE)).isEmpty()
+  }
+
+  @Test
+  fun `sha256 computes hash`() {
+    assertThat(fileSystem.sha256(file = PNG_IMAGE)).isEqualTo(PNG_HASH)
   }
 
   companion object {

--- a/plugin/src/test/kotlin/xyz/block/microfilm/PathsTest.kt
+++ b/plugin/src/test/kotlin/xyz/block/microfilm/PathsTest.kt
@@ -16,10 +16,14 @@
 package xyz.block.microfilm
 
 import assertk.assertThat
+import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
 import assertk.assertions.isTrue
 import okio.Path.Companion.toPath
 import org.junit.jupiter.api.Test
+import xyz.block.microfilm.ImageGroupFixtures.RESOURCES_DIRECTORY
+import xyz.block.microfilm.ImageGroupFixtures.RESOURCES_PNG
+import xyz.block.microfilm.ImageGroupFixtures.RESOURCES_WEBP
 
 class PathsTest {
   @Test
@@ -92,5 +96,26 @@ class PathsTest {
   @Test
   fun `isWebpDrawable is false for directory in drawable directory`() {
     assertThat("src/main/res/drawable/nested".toPath().isWebpDrawable).isFalse()
+  }
+
+  @Test
+  fun `replaceExtension converts from png to webp`() {
+    assertThat(RESOURCES_PNG.replaceExtension(old = "png", new = "webp")).isEqualTo(RESOURCES_WEBP)
+  }
+
+  @Test
+  fun `replaceExtension converts from webp to png`() {
+    assertThat(RESOURCES_WEBP.replaceExtension(old = "webp", new = "png")).isEqualTo(RESOURCES_PNG)
+  }
+
+  @Test
+  fun `replaceExtension skips mismatched extension`() {
+    assertThat(RESOURCES_PNG.replaceExtension(old = "webp", new = "png")).isEqualTo(RESOURCES_PNG)
+  }
+
+  @Test
+  fun `replaceExtension skips directory`() {
+    assertThat(RESOURCES_DIRECTORY.replaceExtension(old = "png", new = "webp"))
+      .isEqualTo(RESOURCES_DIRECTORY)
   }
 }

--- a/plugin/src/test/kotlin/xyz/block/microfilm/compression/CompressCompressorTest.kt
+++ b/plugin/src/test/kotlin/xyz/block/microfilm/compression/CompressCompressorTest.kt
@@ -1,0 +1,189 @@
+/*
+ * Copyright (C) 2026 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package xyz.block.microfilm.compression
+
+import assertk.assertThat
+import assertk.assertions.containsExactly
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
+import okio.ByteString.Companion.encodeUtf8
+import okio.fakefilesystem.FakeFileSystem
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import xyz.block.microfilm.ImageGroupFixtures.EMPTY_IMAGE_GROUP
+import xyz.block.microfilm.ImageGroupFixtures.LOSSLESS_COMPRESS
+import xyz.block.microfilm.ImageGroupFixtures.LOSSLESS_MANIFEST_ENTRY
+import xyz.block.microfilm.ImageGroupFixtures.LOSSY_COMPRESS
+import xyz.block.microfilm.ImageGroupFixtures.LOSSY_IMAGE_GROUP
+import xyz.block.microfilm.ImageGroupFixtures.LOSSY_MANIFEST_ENTRY
+import xyz.block.microfilm.ImageGroupFixtures.MICROFILM_DIRECTORY
+import xyz.block.microfilm.ImageGroupFixtures.MICROFILM_PNG
+import xyz.block.microfilm.ImageGroupFixtures.PNG_CONTENT
+import xyz.block.microfilm.ImageGroupFixtures.RESOURCES_DIRECTORY
+import xyz.block.microfilm.ImageGroupFixtures.RESOURCES_PNG
+import xyz.block.microfilm.ImageGroupFixtures.RESOURCES_WEBP
+import xyz.block.microfilm.ImageGroupFixtures.WEBP_CONTENT
+import xyz.block.microfilm.compression.Compressor.Result.Success
+import xyz.block.microfilm.cwebp.FakeCwebp
+
+class CompressCompressorTest {
+  private val fileSystem =
+    FakeFileSystem().apply {
+      createDirectories(dir = RESOURCES_PNG.parent!!)
+      createDirectories(dir = MICROFILM_PNG.parent!!)
+    }
+  private val cwebp = FakeCwebp(fileSystem = fileSystem, convertToWebp = { WEBP_CONTENT })
+
+  private val compressor =
+    CompressCompressor(
+      cwebp = cwebp,
+      fileSystem = fileSystem,
+      resourcesDirectory = RESOURCES_DIRECTORY,
+      microfilmDirectory = MICROFILM_DIRECTORY,
+    )
+
+  @AfterEach
+  fun tearDown() {
+    fileSystem.checkNoOpenFiles()
+  }
+
+  @Test
+  fun `compress succeeds with resources png`() {
+    fileSystem.write(file = RESOURCES_PNG) { write(PNG_CONTENT.encodeUtf8()) }
+
+    val result =
+      compressor.compress(
+        imageGroup = EMPTY_IMAGE_GROUP.copy(resourcesPng = RESOURCES_PNG),
+        imageSettings = LOSSY_COMPRESS,
+      )
+
+    assertThat(cwebp.compressions).containsExactly(MICROFILM_PNG to RESOURCES_WEBP)
+    assertThat(fileSystem.exists(path = RESOURCES_PNG)).isFalse()
+    assertThat(fileSystem.exists(path = RESOURCES_WEBP)).isTrue()
+    assertThat(fileSystem.exists(path = MICROFILM_PNG)).isTrue()
+    assertThat(result).isEqualTo(Success(microfilmManifestEntry = LOSSY_MANIFEST_ENTRY))
+  }
+
+  @Test
+  fun `compress succeeds with resources webp`() {
+    fileSystem.write(file = RESOURCES_WEBP) { write(WEBP_CONTENT.encodeUtf8()) }
+
+    val result =
+      compressor.compress(
+        imageGroup = EMPTY_IMAGE_GROUP.copy(resourcesWebp = RESOURCES_WEBP),
+        imageSettings = LOSSY_COMPRESS,
+      )
+
+    assertThat(cwebp.compressions).isEmpty()
+    assertThat(fileSystem.exists(path = RESOURCES_PNG)).isFalse()
+    assertThat(fileSystem.exists(path = RESOURCES_WEBP)).isFalse()
+    assertThat(fileSystem.exists(path = MICROFILM_PNG)).isFalse()
+    assertThat(result).isEqualTo(Success(microfilmManifestEntry = null))
+  }
+
+  @Test
+  fun `compress succeeds with microfilm png`() {
+    fileSystem.write(file = MICROFILM_PNG) { write(PNG_CONTENT.encodeUtf8()) }
+
+    val result =
+      compressor.compress(
+        imageGroup = EMPTY_IMAGE_GROUP.copy(microfilmPng = MICROFILM_PNG),
+        imageSettings = LOSSY_COMPRESS,
+      )
+
+    assertThat(cwebp.compressions).containsExactly(MICROFILM_PNG to RESOURCES_WEBP)
+    assertThat(fileSystem.exists(path = RESOURCES_PNG)).isFalse()
+    assertThat(fileSystem.exists(path = RESOURCES_WEBP)).isTrue()
+    assertThat(fileSystem.exists(path = MICROFILM_PNG)).isTrue()
+    assertThat(result).isEqualTo(Success(microfilmManifestEntry = LOSSY_MANIFEST_ENTRY))
+  }
+
+  @Test
+  fun `compress succeeds with microfilm manifest entry`() {
+    val result =
+      compressor.compress(
+        imageGroup = EMPTY_IMAGE_GROUP.copy(microfilmManifestEntry = LOSSY_MANIFEST_ENTRY),
+        imageSettings = LOSSY_COMPRESS,
+      )
+
+    assertThat(cwebp.compressions).isEmpty()
+    assertThat(fileSystem.exists(path = RESOURCES_PNG)).isFalse()
+    assertThat(fileSystem.exists(path = RESOURCES_WEBP)).isFalse()
+    assertThat(fileSystem.exists(path = MICROFILM_PNG)).isFalse()
+    assertThat(result).isEqualTo(Success(microfilmManifestEntry = null))
+  }
+
+  @Test
+  fun `compress succeeds when the png hash is incorrect`() {
+    fileSystem.write(file = RESOURCES_WEBP) { write(WEBP_CONTENT.encodeUtf8()) }
+    fileSystem.write(file = MICROFILM_PNG) { write(PNG_CONTENT.encodeUtf8()) }
+
+    val result =
+      compressor.compress(
+        imageGroup =
+          LOSSY_IMAGE_GROUP.copy(
+            microfilmManifestEntry = LOSSY_MANIFEST_ENTRY.copy(sourceSha256 = "incorrect")
+          ),
+        imageSettings = LOSSY_COMPRESS,
+      )
+
+    assertThat(cwebp.compressions).containsExactly(MICROFILM_PNG to RESOURCES_WEBP)
+    assertThat(result).isEqualTo(Success(microfilmManifestEntry = LOSSY_MANIFEST_ENTRY))
+  }
+
+  @Test
+  fun `compress succeeds when the webp hash is incorrect`() {
+    fileSystem.write(file = RESOURCES_WEBP) { write(WEBP_CONTENT.encodeUtf8()) }
+    fileSystem.write(file = MICROFILM_PNG) { write(PNG_CONTENT.encodeUtf8()) }
+
+    val result =
+      compressor.compress(
+        imageGroup =
+          LOSSY_IMAGE_GROUP.copy(
+            microfilmManifestEntry = LOSSY_MANIFEST_ENTRY.copy(compressedSha256 = "incorrect")
+          ),
+        imageSettings = LOSSY_COMPRESS,
+      )
+
+    assertThat(cwebp.compressions).containsExactly(MICROFILM_PNG to RESOURCES_WEBP)
+    assertThat(result).isEqualTo(Success(microfilmManifestEntry = LOSSY_MANIFEST_ENTRY))
+  }
+
+  @Test
+  fun `compress succeeds when the compression settings are incorrect`() {
+    fileSystem.write(file = RESOURCES_WEBP) { write(WEBP_CONTENT.encodeUtf8()) }
+    fileSystem.write(file = MICROFILM_PNG) { write(PNG_CONTENT.encodeUtf8()) }
+
+    val result =
+      compressor.compress(imageGroup = LOSSY_IMAGE_GROUP, imageSettings = LOSSLESS_COMPRESS)
+
+    assertThat(cwebp.compressions).containsExactly(MICROFILM_PNG to RESOURCES_WEBP)
+    assertThat(result).isEqualTo(Success(microfilmManifestEntry = LOSSLESS_MANIFEST_ENTRY))
+  }
+
+  @Test
+  fun `compress is a no-op when everything is up to date`() {
+    fileSystem.write(file = RESOURCES_WEBP) { write(WEBP_CONTENT.encodeUtf8()) }
+    fileSystem.write(file = MICROFILM_PNG) { write(PNG_CONTENT.encodeUtf8()) }
+
+    val result = compressor.compress(imageGroup = LOSSY_IMAGE_GROUP, imageSettings = LOSSY_COMPRESS)
+
+    assertThat(cwebp.compressions).isEmpty()
+    assertThat(result).isEqualTo(Success(microfilmManifestEntry = LOSSY_MANIFEST_ENTRY))
+  }
+}


### PR DESCRIPTION
## Context
There's a lot of business logic in the Gradle task classes right now. It works, and it's covered in part by our functional tests, but it's a little hard to reason about and unit test.

I want to refactor our approach in a couple ways:
- Move logic out of the Gradle tasks so that it's easier to break down and test
- Use Okio's `FileSystem` instead of regular Java `File`s so that it's easy to fake the disk state in unit tests
- Share file system scanning logic across the compress and verify tasks 
- Introduce the concept of an `ImageGroup` so that it's easy to reason about the compression or verification of a single conceptual image in isolation

## This PR
Adds an implementation of `Compressor` that handles images targeted by a `compress` rule.

The logic is mostly the same as what's currently in `CompressTask`, with one small optimization — we now check to see if everything is up to date with the manifest, and if it is, we skip the call to `cwebp`.