### PR TITLE
Open Renovate PRs immediately so CI can run on them

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,6 +4,11 @@
     'config:recommended',
     'helpers:pinGitHubActionDigests',
   ],
+  // The org-inherited config (block/renovate-config) sets `prCreation: "not-pending"`,
+  // which holds a PR open until the branch's status checks complete. Our CI workflows
+  // only run on `pull_request` (not on pushes to renovate/* branches), so branches never
+  // get checks and the PRs never open. Create PRs immediately so CI can run on them.
+  prCreation: 'immediate',
   ignorePresets: [
     // Ensure we get the latest version and are not pinned to old versions.
     'workarounds:javaLTSVersions',


### PR DESCRIPTION
> fixes https://github.com/block/microfilm/pull/53

The org-inherited Renovate config ([`block/renovate-config`](https://github.com/block/renovate-config/blob/main/org-inherited-config.json)) sets `prCreation: "not-pending"`, which holds off opening a PR until the update branch's status checks complete. This repo's CI (`build.yaml`, `functionalTest.yml`) only triggers on `pull_request` and pushes to `main`, so it never runs on `renovate/*` branches — the branches get no checks, the PRs never open, and dependency updates silently stall (several `renovate/*` branches currently sit with no PR).

This overrides `prCreation` to `immediate` for this repo so PRs open as soon as the branches are created, letting the `pull_request`-triggered CI run and Renovate's automerge flow proceed.