### PR TITLE
Add a `Compressor` that handles images targeted by an `exclude` rule

### DIFF
--- a/plugin/src/main/kotlin/xyz/block/microfilm/compression/ExcludeCompressor.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/compression/ExcludeCompressor.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2026 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package xyz.block.microfilm.compression
+
+import okio.FileSystem
+import okio.Path
+import xyz.block.microfilm.ImageSettings.Exclude
+import xyz.block.microfilm.compression.Compressor.Result
+import xyz.block.microfilm.compression.Compressor.Result.Success
+import xyz.block.microfilm.scanning.ImageGroup
+
+/** A [Compressor] that handles image groups covered by [Exclude] image settings. */
+internal class ExcludeCompressor(
+  private val fileSystem: FileSystem,
+  private val resourcesDirectory: Path,
+  private val microfilmDirectory: Path,
+) : Compressor<Exclude> {
+  override fun compress(imageGroup: ImageGroup, imageSettings: Exclude): Result {
+    val hasResourcesPng = imageGroup.resourcesPng != null
+    val hasMicrofilmPng = imageGroup.microfilmPng != null
+
+    when {
+      // If there is a microfilm png but no resources png, restore the resources png
+      hasMicrofilmPng && !hasResourcesPng -> {
+        val relativePng = imageGroup.microfilmPng.relativeTo(other = microfilmDirectory)
+        val resourcesPng = resourcesDirectory.resolve(child = relativePng)
+        resourcesPng.parent?.let { parent -> fileSystem.createDirectories(dir = parent) }
+        fileSystem.atomicMove(source = imageGroup.microfilmPng, target = resourcesPng)
+      }
+
+      // If there is both a microfilm png and a resources png, delete the microfilm png
+      hasMicrofilmPng && hasResourcesPng -> {
+        fileSystem.delete(path = imageGroup.microfilmPng)
+      }
+    }
+
+    // Return an empty microfilm manifest entry
+    return Success(microfilmManifestEntry = null)
+  }
+}

--- a/plugin/src/test/kotlin/xyz/block/microfilm/compression/ExcludeCompressorTest.kt
+++ b/plugin/src/test/kotlin/xyz/block/microfilm/compression/ExcludeCompressorTest.kt
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2026 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package xyz.block.microfilm.compression
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import okio.ByteString.Companion.encodeUtf8
+import okio.fakefilesystem.FakeFileSystem
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import xyz.block.microfilm.ImageGroupFixtures.EMPTY_IMAGE_GROUP
+import xyz.block.microfilm.ImageGroupFixtures.LOSSY_MANIFEST_ENTRY
+import xyz.block.microfilm.ImageGroupFixtures.MICROFILM_DIRECTORY
+import xyz.block.microfilm.ImageGroupFixtures.MICROFILM_PNG
+import xyz.block.microfilm.ImageGroupFixtures.PNG_CONTENT
+import xyz.block.microfilm.ImageGroupFixtures.RESOURCES_DIRECTORY
+import xyz.block.microfilm.ImageGroupFixtures.RESOURCES_PNG
+import xyz.block.microfilm.ImageGroupFixtures.RESOURCES_WEBP
+import xyz.block.microfilm.ImageSettings.Exclude
+import xyz.block.microfilm.compression.Compressor.Result.Success
+
+class ExcludeCompressorTest {
+  private val fileSystem = FakeFileSystem()
+
+  private val compressor =
+    ExcludeCompressor(
+      fileSystem = fileSystem,
+      resourcesDirectory = RESOURCES_DIRECTORY,
+      microfilmDirectory = MICROFILM_DIRECTORY,
+    )
+
+  @AfterEach
+  fun tearDown() {
+    fileSystem.checkNoOpenFiles()
+  }
+
+  @Test
+  fun `compress succeeds with resources png`() {
+    val result =
+      compressor.compress(
+        imageGroup = EMPTY_IMAGE_GROUP.copy(resourcesPng = RESOURCES_PNG),
+        imageSettings = Exclude,
+      )
+
+    assertThat(result).isEqualTo(Success(microfilmManifestEntry = null))
+  }
+
+  @Test
+  fun `compress succeeds with resources webp`() {
+    val result =
+      compressor.compress(
+        imageGroup = EMPTY_IMAGE_GROUP.copy(resourcesWebp = RESOURCES_WEBP),
+        imageSettings = Exclude,
+      )
+
+    assertThat(result).isEqualTo(Success(microfilmManifestEntry = null))
+  }
+
+  @Test
+  fun `compress succeeds with microfilm png after moving it back to resources`() {
+    fileSystem.createDirectories(dir = MICROFILM_PNG.parent!!)
+    fileSystem.write(file = MICROFILM_PNG) { write(byteString = PNG_CONTENT.encodeUtf8()) }
+
+    val result =
+      compressor.compress(
+        imageGroup = EMPTY_IMAGE_GROUP.copy(microfilmPng = MICROFILM_PNG),
+        imageSettings = Exclude,
+      )
+
+    assertThat(fileSystem.exists(MICROFILM_PNG)).isFalse()
+    assertThat(fileSystem.read(file = RESOURCES_PNG) { readUtf8() }).isEqualTo(PNG_CONTENT)
+    assertThat(result).isEqualTo(Success(microfilmManifestEntry = null))
+  }
+
+  @Test
+  fun `compress succeeds with microfilm png after deleting it`() {
+    fileSystem.createDirectories(dir = RESOURCES_PNG.parent!!)
+    fileSystem.createDirectories(dir = MICROFILM_PNG.parent!!)
+    fileSystem.write(file = RESOURCES_PNG) { write(byteString = PNG_CONTENT.encodeUtf8()) }
+    fileSystem.write(file = MICROFILM_PNG) { write(byteString = "other".encodeUtf8()) }
+
+    val result =
+      compressor.compress(
+        imageGroup =
+          EMPTY_IMAGE_GROUP.copy(resourcesPng = RESOURCES_PNG, microfilmPng = MICROFILM_PNG),
+        imageSettings = Exclude,
+      )
+
+    assertThat(fileSystem.exists(MICROFILM_PNG)).isFalse()
+    assertThat(fileSystem.read(file = RESOURCES_PNG) { readUtf8() }).isEqualTo(PNG_CONTENT)
+    assertThat(result).isEqualTo(Success(microfilmManifestEntry = null))
+  }
+
+  @Test
+  fun `compress succeeds with microfilm manifest entry`() {
+    val result =
+      compressor.compress(
+        imageGroup = EMPTY_IMAGE_GROUP.copy(microfilmManifestEntry = LOSSY_MANIFEST_ENTRY),
+        imageSettings = Exclude,
+      )
+
+    assertThat(result).isEqualTo(Success(microfilmManifestEntry = null))
+  }
+}


### PR DESCRIPTION
## Context
There's a lot of business logic in the Gradle task classes right now. It works, and it's covered in part by our functional tests, but it's a little hard to reason about and unit test.

I want to refactor our approach in a couple ways:
- Move logic out of the Gradle tasks so that it's easier to break down and test
- Use Okio's `FileSystem` instead of regular Java `File`s so that it's easy to fake the disk state in unit tests
- Share file system scanning logic across the compress and verify tasks 
- Introduce the concept of an `ImageGroup` so that it's easy to reason about the compression or verification of a single conceptual image in isolation

## This PR
Adds an implementation of `Compressor` that handles images targeted by an `exclude` rule.