### PR TITLE
Add a `Compressor` that handles images not targeted by a `compress` or an `exclude` rule

### DIFF
--- a/plugin/src/main/kotlin/xyz/block/microfilm/StringBuilders.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/StringBuilders.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2026 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package xyz.block.microfilm
+
+/** Appends a line with a checkbox prefix: [✓] if correct, or [✗] if incorrect. */
+internal fun StringBuilder.appendCheckboxLine(
+  isCorrect: Boolean,
+  correctValue: String,
+  incorrectValue: String,
+) =
+  if (isCorrect) {
+    appendCorrectCheckboxLine(value = correctValue)
+  } else {
+    appendIncorrectCheckboxLine(value = incorrectValue)
+  }
+
+/** Appends a line with a correct checkbox prefix: [✓]. */
+internal fun StringBuilder.appendCorrectCheckboxLine(value: String) = appendLine("[✓] $value")
+
+/** Appends a line with an incorrect checkbox prefix: [✗]. */
+internal fun StringBuilder.appendIncorrectCheckboxLine(value: String) = appendLine("[✗] $value")

--- a/plugin/src/main/kotlin/xyz/block/microfilm/compression/UnspecifiedCompressor.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/compression/UnspecifiedCompressor.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2026 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package xyz.block.microfilm.compression
+
+import okio.FileSystem
+import okio.Path
+import xyz.block.microfilm.ImageSettings.Unspecified
+import xyz.block.microfilm.appendCheckboxLine
+import xyz.block.microfilm.compression.Compressor.Result
+import xyz.block.microfilm.compression.Compressor.Result.Success
+import xyz.block.microfilm.scanning.ImageGroup
+
+/** A [Compressor] that handles image groups covered by [Unspecified] image settings. */
+internal class UnspecifiedCompressor(
+  private val fileSystem: FileSystem,
+  private val resourcesDirectory: Path,
+  private val microfilmDirectory: Path,
+) : Compressor<Unspecified> {
+  override fun compress(imageGroup: ImageGroup, imageSettings: Unspecified): Result {
+    val hasResourcesPng = imageGroup.resourcesPng != null
+    val hasResourcesWebp = imageGroup.resourcesWebp != null
+    val hasMicrofilmPng = imageGroup.microfilmPng != null
+
+    when {
+      // If there is a microfilm png but no resources png, restore the resources png
+      hasMicrofilmPng && !hasResourcesPng -> {
+        val relativePng = imageGroup.microfilmPng.relativeTo(other = microfilmDirectory)
+        val resourcesPng = resourcesDirectory.resolve(child = relativePng)
+        resourcesPng.parent?.let { parent -> fileSystem.createDirectories(dir = parent) }
+        fileSystem.atomicMove(source = imageGroup.microfilmPng, target = resourcesPng)
+      }
+
+      // If there is both a microfilm png and a resources png, delete the microfilm png
+      hasMicrofilmPng && hasResourcesPng -> {
+        fileSystem.delete(path = imageGroup.microfilmPng)
+      }
+    }
+
+    return if (!hasResourcesPng && !hasResourcesWebp && !hasMicrofilmPng) {
+      Success(microfilmManifestEntry = null)
+    } else {
+      Failure(
+        key = imageGroup.key,
+        hasResourcesPng = hasResourcesPng || hasMicrofilmPng,
+        hasResourcesWebp = hasResourcesWebp,
+      )
+    }
+  }
+
+  data class Failure(val key: String, val hasResourcesPng: Boolean, val hasResourcesWebp: Boolean) :
+    Result.Failure {
+    override val description = buildString {
+      appendLine(
+        "Found an image that is covered by neither a `compress` nor an `exclude` rule in the Gradle configuration: $key"
+      )
+
+      appendCheckboxLine(
+        isCorrect = !hasResourcesPng,
+        correctValue = "There is no PNG in the resources directory",
+        incorrectValue = "There is a PNG in the resources directory when none is expected",
+      )
+
+      appendCheckboxLine(
+        isCorrect = !hasResourcesWebp,
+        correctValue = "There is no WebP in the resources directory",
+        incorrectValue = "There is a WebP in the resources directory when none is expected",
+      )
+
+      append(
+        "To fix this failure, add a `compress` or `exclude` rule that covers this image, or delete the image, then rerun the `compressMicrofilm` task."
+      )
+    }
+  }
+}

--- a/plugin/src/test/kotlin/xyz/block/microfilm/StringBuildersTest.kt
+++ b/plugin/src/test/kotlin/xyz/block/microfilm/StringBuildersTest.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2026 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package xyz.block.microfilm
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import org.junit.jupiter.api.Test
+
+class StringBuildersTest {
+  @Test
+  fun `appendCheckboxLine uses checkmark prefix for correct value`() {
+    assertThat(
+        buildString {
+          appendCheckboxLine(
+            isCorrect = true,
+            correctValue = "correct",
+            incorrectValue = "incorrect",
+          )
+        }
+      )
+      .isEqualTo("[✓] correct\n")
+  }
+
+  @Test
+  fun `appendCheckboxLine uses x prefix for incorrect value`() {
+    assertThat(
+        buildString {
+          appendCheckboxLine(
+            isCorrect = false,
+            correctValue = "correct",
+            incorrectValue = "incorrect",
+          )
+        }
+      )
+      .isEqualTo("[✗] incorrect\n")
+  }
+
+  @Test
+  fun `appendCorrectCheckboxLine uses checkmark prefix`() {
+    assertThat(buildString { appendCorrectCheckboxLine(value = "correct") })
+      .isEqualTo("[✓] correct\n")
+  }
+
+  @Test
+  fun `appendIncorrectCheckboxLine uses x prefix`() {
+    assertThat(buildString { appendIncorrectCheckboxLine(value = "incorrect") })
+      .isEqualTo("[✗] incorrect\n")
+  }
+}

--- a/plugin/src/test/kotlin/xyz/block/microfilm/compression/UnspecifiedCompressorTest.kt
+++ b/plugin/src/test/kotlin/xyz/block/microfilm/compression/UnspecifiedCompressorTest.kt
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2026 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package xyz.block.microfilm.compression
+
+import assertk.all
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isInstanceOf
+import assertk.assertions.prop
+import okio.ByteString.Companion.encodeUtf8
+import okio.fakefilesystem.FakeFileSystem
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import xyz.block.microfilm.ImageGroupFixtures.EMPTY_IMAGE_GROUP
+import xyz.block.microfilm.ImageGroupFixtures.KEY
+import xyz.block.microfilm.ImageGroupFixtures.LOSSY_MANIFEST_ENTRY
+import xyz.block.microfilm.ImageGroupFixtures.MICROFILM_DIRECTORY
+import xyz.block.microfilm.ImageGroupFixtures.MICROFILM_PNG
+import xyz.block.microfilm.ImageGroupFixtures.PNG_CONTENT
+import xyz.block.microfilm.ImageGroupFixtures.RESOURCES_DIRECTORY
+import xyz.block.microfilm.ImageGroupFixtures.RESOURCES_PNG
+import xyz.block.microfilm.ImageGroupFixtures.RESOURCES_WEBP
+import xyz.block.microfilm.ImageSettings.Unspecified
+import xyz.block.microfilm.compression.Compressor.Result.Success
+import xyz.block.microfilm.compression.UnspecifiedCompressor.Failure
+
+class UnspecifiedCompressorTest {
+  private val fileSystem = FakeFileSystem()
+
+  private val compressor =
+    UnspecifiedCompressor(
+      fileSystem = fileSystem,
+      resourcesDirectory = RESOURCES_DIRECTORY,
+      microfilmDirectory = MICROFILM_DIRECTORY,
+    )
+
+  @AfterEach
+  fun tearDown() {
+    fileSystem.checkNoOpenFiles()
+  }
+
+  @Test
+  fun `compress fails with resources png`() {
+    val result =
+      compressor.compress(
+        imageGroup = EMPTY_IMAGE_GROUP.copy(resourcesPng = RESOURCES_PNG),
+        imageSettings = Unspecified,
+      )
+
+    assertThat(result).isInstanceOf<Failure>().all {
+      isEqualTo(Failure(key = KEY, hasResourcesPng = true, hasResourcesWebp = false))
+
+      prop(Failure::description)
+        .isEqualTo(
+          """
+          Found an image that is covered by neither a `compress` nor an `exclude` rule in the Gradle configuration: drawable/photo
+          [✗] There is a PNG in the resources directory when none is expected
+          [✓] There is no WebP in the resources directory
+          To fix this failure, add a `compress` or `exclude` rule that covers this image, or delete the image, then rerun the `compressMicrofilm` task.
+          """
+            .trimIndent()
+        )
+    }
+  }
+
+  @Test
+  fun `compress fails with resources webp`() {
+    val result =
+      compressor.compress(
+        imageGroup = EMPTY_IMAGE_GROUP.copy(resourcesWebp = RESOURCES_WEBP),
+        imageSettings = Unspecified,
+      )
+
+    assertThat(result).isInstanceOf<Failure>().all {
+      isEqualTo(Failure(key = KEY, hasResourcesPng = false, hasResourcesWebp = true))
+
+      prop(Failure::description)
+        .isEqualTo(
+          """
+          Found an image that is covered by neither a `compress` nor an `exclude` rule in the Gradle configuration: drawable/photo
+          [✓] There is no PNG in the resources directory
+          [✗] There is a WebP in the resources directory when none is expected
+          To fix this failure, add a `compress` or `exclude` rule that covers this image, or delete the image, then rerun the `compressMicrofilm` task.
+          """
+            .trimIndent()
+        )
+    }
+  }
+
+  @Test
+  fun `compress fails with microfilm png`() {
+    fileSystem.createDirectories(dir = MICROFILM_PNG.parent!!)
+    fileSystem.write(file = MICROFILM_PNG) { write(byteString = PNG_CONTENT.encodeUtf8()) }
+
+    val result =
+      compressor.compress(
+        imageGroup = EMPTY_IMAGE_GROUP.copy(microfilmPng = MICROFILM_PNG),
+        imageSettings = Unspecified,
+      )
+
+    assertThat(fileSystem.exists(MICROFILM_PNG)).isFalse()
+    assertThat(fileSystem.read(file = RESOURCES_PNG) { readUtf8() }).isEqualTo(PNG_CONTENT)
+    assertThat(result).isInstanceOf<Failure>().all {
+      isEqualTo(Failure(key = KEY, hasResourcesPng = true, hasResourcesWebp = false))
+
+      prop(Failure::description)
+        .isEqualTo(
+          """
+          Found an image that is covered by neither a `compress` nor an `exclude` rule in the Gradle configuration: drawable/photo
+          [✗] There is a PNG in the resources directory when none is expected
+          [✓] There is no WebP in the resources directory
+          To fix this failure, add a `compress` or `exclude` rule that covers this image, or delete the image, then rerun the `compressMicrofilm` task.
+          """
+            .trimIndent()
+        )
+    }
+  }
+
+  @Test
+  fun `compress succeeds with microfilm manifest entry`() {
+    val result =
+      compressor.compress(
+        imageGroup = EMPTY_IMAGE_GROUP.copy(microfilmManifestEntry = LOSSY_MANIFEST_ENTRY),
+        imageSettings = Unspecified,
+      )
+
+    assertThat(result).isEqualTo(Success(microfilmManifestEntry = null))
+  }
+}


### PR DESCRIPTION
## Context
There's a lot of business logic in the Gradle task classes right now. It works, and it's covered in part by our functional tests, but it's a little hard to reason about and unit test.

I want to refactor our approach in a couple ways:
- Move logic out of the Gradle tasks so that it's easier to break down and test
- Use Okio's `FileSystem` instead of regular Java `File`s so that it's easy to fake the disk state in unit tests
- Share file system scanning logic across the compress and verify tasks 
- Introduce the concept of an `ImageGroup` so that it's easy to reason about the compression or verification of a single conceptual image in isolation

## This PR
Adds an implementation of `Compressor` that handles images not targeted by a `compress` or an `exclude` rule.

Currently we ignore images that aren't targeted by a rule, but now we're going to report them as errors. If developers want to maintain the current behavior they can use a default `exclude("**")` rule.

The errors try to specifically diagnose the root cause and explain the fix. They look something like this:
```
Found an image that is covered by neither a `compress` nor an `exclude` rule in the Gradle configuration: drawable/photo
[✗] There is a PNG in the resources directory when none is expected
[✓] There is no WebP in the resources directory
To fix this failure, add a `compress` or `exclude` rule that covers this image, or delete the image, then rerun the `compressMicrofilm` task.
```