### PR TITLE
Add a `Verifier` interface and an implementation that delegates based on the image settings type

### DIFF
--- a/plugin/src/main/kotlin/xyz/block/microfilm/verification/TypedVerifier.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/verification/TypedVerifier.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2026 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package xyz.block.microfilm.verification
+
+import xyz.block.microfilm.ImageSettings
+import xyz.block.microfilm.ImageSettings.Compress
+import xyz.block.microfilm.ImageSettings.Exclude
+import xyz.block.microfilm.ImageSettings.Unspecified
+import xyz.block.microfilm.scanning.ImageGroup
+import xyz.block.microfilm.verification.Verifier.Result
+
+/** A [Verifier] that delegates to individual verifiers for each subclass of [ImageSettings]. */
+internal class TypedVerifier(
+  private val compressVerifier: Verifier<Compress>,
+  private val excludeVerifier: Verifier<Exclude>,
+  private val unspecifiedVerifier: Verifier<Unspecified>,
+) : Verifier<ImageSettings> {
+  override fun verify(imageGroup: ImageGroup, imageSettings: ImageSettings): Result {
+    return when (imageSettings) {
+      is Compress -> compressVerifier.verify(imageGroup = imageGroup, imageSettings = imageSettings)
+      is Exclude -> excludeVerifier.verify(imageGroup = imageGroup, imageSettings = imageSettings)
+      is Unspecified ->
+        unspecifiedVerifier.verify(imageGroup = imageGroup, imageSettings = imageSettings)
+    }
+  }
+}

--- a/plugin/src/main/kotlin/xyz/block/microfilm/verification/Verifier.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/verification/Verifier.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2026 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package xyz.block.microfilm.verification
+
+import xyz.block.microfilm.ImageSettings
+import xyz.block.microfilm.scanning.ImageGroup
+
+/**
+ * A verifier that checks images against the image settings declared in the Gradle configuration.
+ */
+internal interface Verifier<T : ImageSettings> {
+  /** Verifies the given image using the given settings . */
+  fun verify(imageGroup: ImageGroup, imageSettings: T): Result
+
+  sealed interface Result {
+    /** The key of the [ImageGroup] that was verified. */
+    val key: String
+
+    /** Returned when an image passes verification. */
+    data class Success(override val key: String) : Result
+
+    /** Returned when an image fails verification for some reason. */
+    sealed interface Failure : Result {
+      val description: String
+    }
+  }
+}

--- a/plugin/src/test/kotlin/xyz/block/microfilm/verification/FakeVerifier.kt
+++ b/plugin/src/test/kotlin/xyz/block/microfilm/verification/FakeVerifier.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2026 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package xyz.block.microfilm.verification
+
+import xyz.block.microfilm.ImageSettings
+import xyz.block.microfilm.scanning.ImageGroup
+import xyz.block.microfilm.verification.Verifier.Result
+import xyz.block.microfilm.verification.Verifier.Result.Success
+
+internal class FakeVerifier<T : ImageSettings> : Verifier<T> {
+  val verifyRequests = ArrayDeque<Pair<ImageGroup, ImageSettings>>()
+  val verifyResponses = ArrayDeque<Result>()
+
+  override fun verify(imageGroup: ImageGroup, imageSettings: T): Result {
+    verifyRequests.add(imageGroup to imageSettings)
+    return verifyResponses.removeFirstOrNull() ?: Success(key = imageGroup.key)
+  }
+}

--- a/plugin/src/test/kotlin/xyz/block/microfilm/verification/TypedVerifierTest.kt
+++ b/plugin/src/test/kotlin/xyz/block/microfilm/verification/TypedVerifierTest.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2026 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package xyz.block.microfilm.verification
+
+import assertk.assertThat
+import assertk.assertions.containsExactly
+import assertk.assertions.isEmpty
+import org.junit.jupiter.api.Test
+import xyz.block.microfilm.ImageGroupFixtures.LOSSY_COMPRESS
+import xyz.block.microfilm.ImageGroupFixtures.LOSSY_IMAGE_GROUP
+import xyz.block.microfilm.ImageSettings.Compress
+import xyz.block.microfilm.ImageSettings.Exclude
+import xyz.block.microfilm.ImageSettings.Unspecified
+
+class TypedVerifierTest {
+  private val compressVerifier = FakeVerifier<Compress>()
+  private val excludeVerifier = FakeVerifier<Exclude>()
+  private val unspecifiedVerifier = FakeVerifier<Unspecified>()
+
+  private val verifier =
+    TypedVerifier(
+      compressVerifier = compressVerifier,
+      excludeVerifier = excludeVerifier,
+      unspecifiedVerifier = unspecifiedVerifier,
+    )
+
+  @Test
+  fun `verify delegates to compress verifier`() {
+    verifier.verify(imageGroup = LOSSY_IMAGE_GROUP, imageSettings = LOSSY_COMPRESS)
+
+    assertThat(compressVerifier.verifyRequests).containsExactly(LOSSY_IMAGE_GROUP to LOSSY_COMPRESS)
+    assertThat(excludeVerifier.verifyRequests).isEmpty()
+    assertThat(unspecifiedVerifier.verifyRequests).isEmpty()
+  }
+
+  @Test
+  fun `verify delegates to exclude verifier`() {
+    verifier.verify(imageGroup = LOSSY_IMAGE_GROUP, imageSettings = Exclude)
+
+    assertThat(compressVerifier.verifyRequests).isEmpty()
+    assertThat(excludeVerifier.verifyRequests).containsExactly(LOSSY_IMAGE_GROUP to Exclude)
+    assertThat(unspecifiedVerifier.verifyRequests).isEmpty()
+  }
+
+  @Test
+  fun `verify delegates to unspecified verifier`() {
+    verifier.verify(imageGroup = LOSSY_IMAGE_GROUP, imageSettings = Unspecified)
+
+    assertThat(compressVerifier.verifyRequests).isEmpty()
+    assertThat(excludeVerifier.verifyRequests).isEmpty()
+    assertThat(unspecifiedVerifier.verifyRequests).containsExactly(LOSSY_IMAGE_GROUP to Unspecified)
+  }
+}


### PR DESCRIPTION
## Context
There's a lot of business logic in the Gradle task classes right now. It works, and it's covered in part by our functional tests, but it's a little hard to reason about and unit test.

I want to refactor our approach in a couple ways:
- Move logic out of the Gradle tasks so that it's easier to break down and test
- Use Okio's `FileSystem` instead of regular Java `File`s so that it's easy to fake the disk state in unit tests
- Share file system scanning logic across the compress and verify tasks 
- Introduce the concept of an `ImageGroup` so that it's easy to reason about the compression or verification of a single conceptual image in isolation

## This PR
Introduces a new `Verifier` interface that we'll use to implement `VerifyTask`.

Ultimately this interface will have a couple implementations:
- `CompressVerifier`: handles images targeted by a `compress` rule
- `ExcludeVerifier`: handles images targeted by an `exclude` rule
- `UnspecifiedVerifier`: handles images not targeted by any rule
- `TypedVerifier`: a small utility that delegates to each of the three verifiers above by type

The structure here closely mirrors what we just did with `Compressor` and all of its implementations.