### PR TITLE
Add a `Verifier` that handles images targeted by an `exclude` rule

### DIFF
--- a/plugin/src/main/kotlin/xyz/block/microfilm/verification/ExcludeVerifier.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/verification/ExcludeVerifier.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2026 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package xyz.block.microfilm.verification
+
+import xyz.block.microfilm.ImageSettings.Exclude
+import xyz.block.microfilm.appendCheckboxLine
+import xyz.block.microfilm.scanning.ImageGroup
+import xyz.block.microfilm.verification.Verifier.Result
+import xyz.block.microfilm.verification.Verifier.Result.Success
+
+/** A [Verifier] that handles image groups covered by [Exclude] image settings. */
+internal class ExcludeVerifier : Verifier<Exclude> {
+  override fun verify(imageGroup: ImageGroup, imageSettings: Exclude): Result {
+    val hasMicrofilmPng = imageGroup.microfilmPng != null
+    val hasMicrofilmManifestEntry = imageGroup.microfilmManifestEntry != null
+
+    return if (!hasMicrofilmPng && !hasMicrofilmManifestEntry) {
+      Success(key = imageGroup.key)
+    } else {
+      Failure(
+        key = imageGroup.key,
+        hasMicrofilmPng = hasMicrofilmPng,
+        hasMicrofilmManifestEntry = hasMicrofilmManifestEntry,
+      )
+    }
+  }
+
+  data class Failure(
+    override val key: String,
+    val hasMicrofilmPng: Boolean,
+    val hasMicrofilmManifestEntry: Boolean,
+  ) : Result.Failure {
+    override val description = buildString {
+      appendLine(
+        "Found an image that is covered by an `exclude` rule in the Gradle configuration but is not fully excluded: $key"
+      )
+
+      appendCheckboxLine(
+        isCorrect = !hasMicrofilmPng,
+        correctValue = "There is no PNG in the microfilm directory",
+        incorrectValue = "There is a PNG in the microfilm directory when none is expected",
+      )
+
+      appendCheckboxLine(
+        isCorrect = !hasMicrofilmManifestEntry,
+        correctValue = "There is no entry in the microfilm manifest",
+        incorrectValue = "There is an entry in the microfilm manifest when none is expected",
+      )
+
+      append("To fix this failure, run the `compressMicrofilm` task.")
+    }
+  }
+}

--- a/plugin/src/test/kotlin/xyz/block/microfilm/verification/ExcludeVerifierTest.kt
+++ b/plugin/src/test/kotlin/xyz/block/microfilm/verification/ExcludeVerifierTest.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2026 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package xyz.block.microfilm.verification
+
+import assertk.all
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import assertk.assertions.prop
+import org.junit.jupiter.api.Test
+import xyz.block.microfilm.ImageGroupFixtures.EMPTY_IMAGE_GROUP
+import xyz.block.microfilm.ImageGroupFixtures.KEY
+import xyz.block.microfilm.ImageGroupFixtures.LOSSY_MANIFEST_ENTRY
+import xyz.block.microfilm.ImageGroupFixtures.MICROFILM_PNG
+import xyz.block.microfilm.ImageGroupFixtures.RESOURCES_PNG
+import xyz.block.microfilm.ImageGroupFixtures.RESOURCES_WEBP
+import xyz.block.microfilm.ImageSettings.Exclude
+import xyz.block.microfilm.verification.ExcludeVerifier.Failure
+import xyz.block.microfilm.verification.Verifier.Result.Success
+
+class ExcludeVerifierTest {
+  private val verifier = ExcludeVerifier()
+
+  @Test
+  fun `verify succeeds with resources png`() {
+    val result =
+      verifier.verify(
+        imageGroup = EMPTY_IMAGE_GROUP.copy(resourcesPng = RESOURCES_PNG),
+        imageSettings = Exclude,
+      )
+
+    assertThat(result).isEqualTo(Success(key = KEY))
+  }
+
+  @Test
+  fun `verify succeeds with resources webp`() {
+    val result =
+      verifier.verify(
+        imageGroup = EMPTY_IMAGE_GROUP.copy(resourcesWebp = RESOURCES_WEBP),
+        imageSettings = Exclude,
+      )
+
+    assertThat(result).isEqualTo(Success(key = KEY))
+  }
+
+  @Test
+  fun `verify fails with microfilm png`() {
+    val result =
+      verifier.verify(
+        imageGroup = EMPTY_IMAGE_GROUP.copy(microfilmPng = MICROFILM_PNG),
+        imageSettings = Exclude,
+      )
+
+    assertThat(result).isInstanceOf<Failure>().all {
+      isEqualTo(Failure(key = KEY, hasMicrofilmPng = true, hasMicrofilmManifestEntry = false))
+
+      prop(Failure::description)
+        .isEqualTo(
+          """
+          Found an image that is covered by an `exclude` rule in the Gradle configuration but is not fully excluded: drawable/photo
+          [✗] There is a PNG in the microfilm directory when none is expected
+          [✓] There is no entry in the microfilm manifest
+          To fix this failure, run the `compressMicrofilm` task.
+          """
+            .trimIndent()
+        )
+    }
+  }
+
+  @Test
+  fun `verify fails with microfilm manifest entry`() {
+    val result =
+      verifier.verify(
+        imageGroup = EMPTY_IMAGE_GROUP.copy(microfilmManifestEntry = LOSSY_MANIFEST_ENTRY),
+        imageSettings = Exclude,
+      )
+
+    assertThat(result).isInstanceOf<Failure>().all {
+      isEqualTo(Failure(key = KEY, hasMicrofilmPng = false, hasMicrofilmManifestEntry = true))
+
+      prop(Failure::description)
+        .isEqualTo(
+          """
+          Found an image that is covered by an `exclude` rule in the Gradle configuration but is not fully excluded: drawable/photo
+          [✓] There is no PNG in the microfilm directory
+          [✗] There is an entry in the microfilm manifest when none is expected
+          To fix this failure, run the `compressMicrofilm` task.
+          """
+            .trimIndent()
+        )
+    }
+  }
+}


### PR DESCRIPTION
## Context
There's a lot of business logic in the Gradle task classes right now. It works, and it's covered in part by our functional tests, but it's a little hard to reason about and unit test.

I want to refactor our approach in a couple ways:
- Move logic out of the Gradle tasks so that it's easier to break down and test
- Use Okio's `FileSystem` instead of regular Java `File`s so that it's easy to fake the disk state in unit tests
- Share file system scanning logic across the compress and verify tasks 
- Introduce the concept of an `ImageGroup` so that it's easy to reason about the compression or verification of a single conceptual image in isolation

## This PR
Adds an implementation of `Verifier` that handles images targeted by an `exclude` rule.

It produces errors that look something like this:
```
Found an image that is covered by an `exclude` rule in the Gradle configuration but is not fully excluded: drawable/photo
[✗] There is a PNG in the microfilm directory when none is expected
[✓] There is no entry in the microfilm manifest
To fix this failure, run the `compressMicrofilm` task.
```