### PR TITLE
Add a `Verifier` that handles images not targeted by a `compress` or an `exclude` rule

### DIFF
--- a/plugin/src/main/kotlin/xyz/block/microfilm/verification/UnspecifiedVerifier.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/verification/UnspecifiedVerifier.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2026 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package xyz.block.microfilm.verification
+
+import xyz.block.microfilm.ImageSettings.Unspecified
+import xyz.block.microfilm.appendCheckboxLine
+import xyz.block.microfilm.scanning.ImageGroup
+import xyz.block.microfilm.verification.Verifier.Result
+import xyz.block.microfilm.verification.Verifier.Result.Success
+
+internal class UnspecifiedVerifier : Verifier<Unspecified> {
+  override fun verify(imageGroup: ImageGroup, imageSettings: Unspecified): Result {
+    val hasResourcesPng = imageGroup.resourcesPng != null
+    val hasResourcesWebp = imageGroup.resourcesWebp != null
+    val hasMicrofilmPng = imageGroup.microfilmPng != null
+    val hasMicrofilmManifestEntry = imageGroup.microfilmManifestEntry != null
+
+    return if (
+      !hasResourcesPng && !hasResourcesWebp && !hasMicrofilmPng && !hasMicrofilmManifestEntry
+    ) {
+      Success(key = imageGroup.key)
+    } else {
+      Failure(
+        key = imageGroup.key,
+        hasResourcesPng = hasResourcesPng,
+        hasMicrofilmPng = hasMicrofilmPng,
+        hasResourcesWebp = hasResourcesWebp,
+        hasMicrofilmManifestEntry = hasMicrofilmManifestEntry,
+      )
+    }
+  }
+
+  data class Failure(
+    override val key: String,
+    val hasResourcesPng: Boolean,
+    val hasResourcesWebp: Boolean,
+    val hasMicrofilmPng: Boolean,
+    val hasMicrofilmManifestEntry: Boolean,
+  ) : Result.Failure {
+    override val description = buildString {
+      appendLine(
+        "Found an image that is covered by neither a `compress` nor an `exclude` rule in the Gradle configuration: $key"
+      )
+
+      appendCheckboxLine(
+        isCorrect = !hasResourcesPng,
+        correctValue = "There is no PNG in the resources directory",
+        incorrectValue = "There is a PNG in the resources directory when none is expected",
+      )
+
+      appendCheckboxLine(
+        isCorrect = !hasResourcesWebp,
+        correctValue = "There is no WebP in the resources directory",
+        incorrectValue = "There is a WebP in the resources directory when none is expected",
+      )
+
+      appendCheckboxLine(
+        isCorrect = !hasMicrofilmPng,
+        correctValue = "There is no PNG in the microfilm directory",
+        incorrectValue = "There is a PNG in the microfilm directory when none is expected",
+      )
+
+      appendCheckboxLine(
+        isCorrect = !hasMicrofilmManifestEntry,
+        correctValue = "There is no entry in the microfilm manifest",
+        incorrectValue = "There is an entry in the microfilm manifest when none is expected",
+      )
+
+      append(
+        "To fix this failure, add a `compress` or `exclude` rule that covers this image, or delete the image, then run the `compressMicrofilm` task."
+      )
+    }
+  }
+}

--- a/plugin/src/test/kotlin/xyz/block/microfilm/verification/UnspecifiedVerifierTest.kt
+++ b/plugin/src/test/kotlin/xyz/block/microfilm/verification/UnspecifiedVerifierTest.kt
@@ -1,0 +1,171 @@
+/*
+ * Copyright (C) 2026 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package xyz.block.microfilm.verification
+
+import assertk.all
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import assertk.assertions.prop
+import org.junit.jupiter.api.Test
+import xyz.block.microfilm.ImageGroupFixtures.EMPTY_IMAGE_GROUP
+import xyz.block.microfilm.ImageGroupFixtures.KEY
+import xyz.block.microfilm.ImageGroupFixtures.LOSSY_MANIFEST_ENTRY
+import xyz.block.microfilm.ImageGroupFixtures.MICROFILM_PNG
+import xyz.block.microfilm.ImageGroupFixtures.RESOURCES_PNG
+import xyz.block.microfilm.ImageGroupFixtures.RESOURCES_WEBP
+import xyz.block.microfilm.ImageSettings.Unspecified
+import xyz.block.microfilm.verification.UnspecifiedVerifier.Failure
+
+class UnspecifiedVerifierTest {
+  private val verifier = UnspecifiedVerifier()
+
+  @Test
+  fun `verify fails with resources png`() {
+    val result =
+      verifier.verify(
+        imageGroup = EMPTY_IMAGE_GROUP.copy(resourcesPng = RESOURCES_PNG),
+        imageSettings = Unspecified,
+      )
+
+    assertThat(result).isInstanceOf<Failure>().all {
+      isEqualTo(
+        Failure(
+          key = KEY,
+          hasResourcesPng = true,
+          hasResourcesWebp = false,
+          hasMicrofilmPng = false,
+          hasMicrofilmManifestEntry = false,
+        )
+      )
+
+      prop(Failure::description)
+        .isEqualTo(
+          """
+          Found an image that is covered by neither a `compress` nor an `exclude` rule in the Gradle configuration: drawable/photo
+          [✗] There is a PNG in the resources directory when none is expected
+          [✓] There is no WebP in the resources directory
+          [✓] There is no PNG in the microfilm directory
+          [✓] There is no entry in the microfilm manifest
+          To fix this failure, add a `compress` or `exclude` rule that covers this image, or delete the image, then run the `compressMicrofilm` task.
+          """
+            .trimIndent()
+        )
+    }
+  }
+
+  @Test
+  fun `verify fails with resources webp`() {
+    val result =
+      verifier.verify(
+        imageGroup = EMPTY_IMAGE_GROUP.copy(resourcesWebp = RESOURCES_WEBP),
+        imageSettings = Unspecified,
+      )
+
+    assertThat(result).isInstanceOf<Failure>().all {
+      isEqualTo(
+        Failure(
+          key = KEY,
+          hasResourcesPng = false,
+          hasResourcesWebp = true,
+          hasMicrofilmPng = false,
+          hasMicrofilmManifestEntry = false,
+        )
+      )
+
+      prop(Failure::description)
+        .isEqualTo(
+          """
+          Found an image that is covered by neither a `compress` nor an `exclude` rule in the Gradle configuration: drawable/photo
+          [✓] There is no PNG in the resources directory
+          [✗] There is a WebP in the resources directory when none is expected
+          [✓] There is no PNG in the microfilm directory
+          [✓] There is no entry in the microfilm manifest
+          To fix this failure, add a `compress` or `exclude` rule that covers this image, or delete the image, then run the `compressMicrofilm` task.
+          """
+            .trimIndent()
+        )
+    }
+  }
+
+  @Test
+  fun `verify fails with microfilm png`() {
+    val result =
+      verifier.verify(
+        imageGroup = EMPTY_IMAGE_GROUP.copy(microfilmPng = MICROFILM_PNG),
+        imageSettings = Unspecified,
+      )
+
+    assertThat(result).isInstanceOf<Failure>().all {
+      isEqualTo(
+        Failure(
+          key = KEY,
+          hasResourcesPng = false,
+          hasResourcesWebp = false,
+          hasMicrofilmPng = true,
+          hasMicrofilmManifestEntry = false,
+        )
+      )
+
+      prop(Failure::description)
+        .isEqualTo(
+          """
+          Found an image that is covered by neither a `compress` nor an `exclude` rule in the Gradle configuration: drawable/photo
+          [✓] There is no PNG in the resources directory
+          [✓] There is no WebP in the resources directory
+          [✗] There is a PNG in the microfilm directory when none is expected
+          [✓] There is no entry in the microfilm manifest
+          To fix this failure, add a `compress` or `exclude` rule that covers this image, or delete the image, then run the `compressMicrofilm` task.
+          """
+            .trimIndent()
+        )
+    }
+  }
+
+  @Test
+  fun `verify fails with microfilm manifest entry`() {
+    val result =
+      verifier.verify(
+        imageGroup = EMPTY_IMAGE_GROUP.copy(microfilmManifestEntry = LOSSY_MANIFEST_ENTRY),
+        imageSettings = Unspecified,
+      )
+
+    assertThat(result).isInstanceOf<Failure>().all {
+      isEqualTo(
+        Failure(
+          key = KEY,
+          hasResourcesPng = false,
+          hasResourcesWebp = false,
+          hasMicrofilmPng = false,
+          hasMicrofilmManifestEntry = true,
+        )
+      )
+
+      prop(Failure::description)
+        .isEqualTo(
+          """
+          Found an image that is covered by neither a `compress` nor an `exclude` rule in the Gradle configuration: drawable/photo
+          [✓] There is no PNG in the resources directory
+          [✓] There is no WebP in the resources directory
+          [✓] There is no PNG in the microfilm directory
+          [✗] There is an entry in the microfilm manifest when none is expected
+          To fix this failure, add a `compress` or `exclude` rule that covers this image, or delete the image, then run the `compressMicrofilm` task.
+          """
+            .trimIndent()
+        )
+    }
+  }
+}


### PR DESCRIPTION
## Context
There's a lot of business logic in the Gradle task classes right now. It works, and it's covered in part by our functional tests, but it's a little hard to reason about and unit test.

I want to refactor our approach in a couple ways:
- Move logic out of the Gradle tasks so that it's easier to break down and test
- Use Okio's `FileSystem` instead of regular Java `File`s so that it's easy to fake the disk state in unit tests
- Share file system scanning logic across the compress and verify tasks 
- Introduce the concept of an `ImageGroup` so that it's easy to reason about the compression or verification of a single conceptual image in isolation

## This PR
Adds an implementation of `Verifier` that handles images not targeted by a `compress` or an `exclude` rule.

Currently we ignore images that aren't targeted by a rule, but now we're going to report them as errors. If developers want to maintain the current behavior they can use a default `exclude("**")` rule.

It produces errors that look something like this:
```
Found an image that is covered by neither a `compress` nor an `exclude` rule in the Gradle configuration: drawable/photo
[✗] There is a PNG in the resources directory when none is expected
[✓] There is no WebP in the resources directory
[✓] There is no PNG in the microfilm directory
[✓] There is no entry in the microfilm manifest
To fix this failure, add a `compress` or `exclude` rule that covers this image, or delete the image, then run the `compressMicrofilm` task.
```