### PR TITLE
[RFC] Add a task to decompress images

### DIFF
--- a/plugin/src/main/kotlin/xyz/block/microfilm/MicrofilmPlugin.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/MicrofilmPlugin.kt
@@ -36,6 +36,7 @@ import org.gradle.nativeplatform.OperatingSystemFamily.MACOS
 import org.gradle.nativeplatform.OperatingSystemFamily.OPERATING_SYSTEM_ATTRIBUTE
 import xyz.block.microfilm.compression.CompressTask
 import xyz.block.microfilm.cwebp.ExtractCwebpBinary
+import xyz.block.microfilm.decompression.DecompressTask
 import xyz.block.microfilm.verification.VerifyTask
 
 public class MicrofilmPlugin : Plugin<Project> {
@@ -95,6 +96,11 @@ public class MicrofilmPlugin : Plugin<Project> {
         task.description = "Compresses source images and updates the manifest for all source sets"
         task.group = "microfilm"
       }
+    val decompress =
+      tasks.register("decompressMicrofilm") { task ->
+        task.description = "Decompresses source images and removes the manifest for all source sets"
+        task.group = "microfilm"
+      }
     val verify =
       tasks.register("verifyMicrofilm") { task ->
         task.description = "Verifies that the manifest is up to date for all source sets"
@@ -107,6 +113,7 @@ public class MicrofilmPlugin : Plugin<Project> {
         extension = extension,
         cwebpDirectory = cwebpDirectory,
         compress = compress,
+        decompress = decompress,
         verify = verify,
       )
     }
@@ -115,6 +122,7 @@ public class MicrofilmPlugin : Plugin<Project> {
         extension = extension,
         cwebpDirectory = cwebpDirectory,
         compress = compress,
+        decompress = decompress,
         verify = verify,
       )
     }
@@ -132,6 +140,7 @@ public class MicrofilmPlugin : Plugin<Project> {
     extension: MicrofilmExtension,
     cwebpDirectory: FileCollection,
     compress: TaskProvider<*>,
+    decompress: TaskProvider<*>,
     verify: TaskProvider<*>,
   ) {
     extensions.getByType(CommonExtension::class.java).sourceSets.configureEach { sourceSet ->
@@ -158,6 +167,15 @@ public class MicrofilmPlugin : Plugin<Project> {
           task.outputs.upToDateWhen { false }
           task.onlyIf { hasMicrofilmContent() }
         }
+      val decompressSourceSet =
+        tasks.register("decompressMicrofilm$nameCapitalized", DecompressTask::class.java) { task ->
+          task.description = "Decompresses source images for the '$name' source set"
+          task.group = "microfilm"
+          task.microfilmDirectory.set(microfilmDirectory)
+          task.resourcesDirectory.set(resourcesDirectory)
+          task.outputs.upToDateWhen { false }
+          task.onlyIf { hasMicrofilmContent() }
+        }
       val verifySourceSet =
         tasks.register("verifyMicrofilm$nameCapitalized", VerifyTask::class.java) { task ->
           task.description = "Verifies that the manifest is up to date for the '$name' source set"
@@ -171,6 +189,7 @@ public class MicrofilmPlugin : Plugin<Project> {
 
       // Link the subtasks to the parent tasks
       compress.configure { it.dependsOn(compressSourceSet) }
+      decompress.configure { it.dependsOn(decompressSourceSet) }
       verify.configure { it.dependsOn(verifySourceSet) }
     }
   }

--- a/plugin/src/main/kotlin/xyz/block/microfilm/decompression/DecompressTask.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/decompression/DecompressTask.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2026 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package xyz.block.microfilm.decompression
+
+import okio.FileSystem
+import okio.Path.Companion.toOkioPath
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
+import xyz.block.microfilm.scanning.RealScanner
+
+@DisableCachingByDefault(because = "This task modifies the source tree in place")
+internal abstract class DecompressTask : DefaultTask() {
+  @get:Internal abstract val microfilmDirectory: DirectoryProperty
+
+  @get:Internal abstract val resourcesDirectory: DirectoryProperty
+
+  private val resourcesDirectoryPath by lazy { resourcesDirectory.get().asFile.toOkioPath() }
+  private val microfilmDirectoryPath by lazy { microfilmDirectory.get().asFile.toOkioPath() }
+  private val microfilmManifestPath by lazy {
+    microfilmDirectoryPath.resolve(child = "manifest.json")
+  }
+
+  @TaskAction
+  fun decompress() {
+    // Initialize the dependencies
+    val fileSystem = FileSystem.SYSTEM
+    val scanner =
+      RealScanner(
+        fileSystem = fileSystem,
+        resourcesDirectory = resourcesDirectoryPath,
+        microfilmDirectory = microfilmDirectoryPath,
+      )
+    val decompressor =
+      RealDecompressor(
+        fileSystem = fileSystem,
+        resourcesDirectory = resourcesDirectoryPath,
+        microfilmDirectory = microfilmDirectoryPath,
+      )
+
+    // Decompress the images
+    scanner.scan().forEach { imageGroup ->
+      decompressor.decompress(imageGroup = imageGroup)
+    }
+
+    // Delete the manifest
+    fileSystem.delete(path = microfilmManifestPath)
+  }
+}

--- a/plugin/src/main/kotlin/xyz/block/microfilm/decompression/Decompressor.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/decompression/Decompressor.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2026 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package xyz.block.microfilm.decompression
+
+import xyz.block.microfilm.scanning.ImageGroup
+
+/**
+ * A decompressor that removes compressed images and restores their original uncompressed
+ * counterparts.
+ */
+internal interface Decompressor {
+  /** Removes the given compressed image and restores its original uncompressed counterpart. */
+  fun decompress(imageGroup: ImageGroup)
+}

--- a/plugin/src/main/kotlin/xyz/block/microfilm/decompression/RealDecompressor.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/decompression/RealDecompressor.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2026 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package xyz.block.microfilm.decompression
+
+import okio.FileSystem
+import okio.Path
+import xyz.block.microfilm.scanning.ImageGroup
+
+internal class RealDecompressor(
+  private val fileSystem: FileSystem,
+  private val resourcesDirectory: Path,
+  private val microfilmDirectory: Path,
+) : Decompressor {
+  override fun decompress(imageGroup: ImageGroup) {
+    var resourcesPng = imageGroup.resourcesPng
+    val resourcesWebp = imageGroup.resourcesWebp
+    val microfilmPng = imageGroup.microfilmPng
+
+    // If there's a microfilm png, move it back to the resources directory
+    if (microfilmPng != null) {
+      val relativePng = microfilmPng.relativeTo(other = microfilmDirectory)
+      resourcesPng = resourcesDirectory.resolve(child = relativePng)
+      resourcesPng.parent?.let { parent -> fileSystem.createDirectories(dir = parent) }
+      fileSystem.atomicMove(source = microfilmPng, target = resourcesPng)
+    }
+
+    // If there's a resources png and a resources webp, delete the webp
+    if (resourcesPng != null && resourcesWebp != null) {
+      fileSystem.delete(path = resourcesWebp)
+    }
+  }
+}

--- a/plugin/src/test/kotlin/xyz/block/microfilm/decompression/RealDecompressorTest.kt
+++ b/plugin/src/test/kotlin/xyz/block/microfilm/decompression/RealDecompressorTest.kt
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2026 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package xyz.block.microfilm.decompression
+
+import assertk.assertThat
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
+import okio.ByteString.Companion.encodeUtf8
+import okio.fakefilesystem.FakeFileSystem
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import xyz.block.microfilm.scanning.ImageGroupFixtures.EMPTY_IMAGE_GROUP
+import xyz.block.microfilm.scanning.ImageGroupFixtures.LOSSY_IMAGE_GROUP
+import xyz.block.microfilm.scanning.ImageGroupFixtures.LOSSY_MANIFEST_ENTRY
+import xyz.block.microfilm.scanning.ImageGroupFixtures.MICROFILM_DIRECTORY
+import xyz.block.microfilm.scanning.ImageGroupFixtures.MICROFILM_PNG
+import xyz.block.microfilm.scanning.ImageGroupFixtures.PNG_CONTENT
+import xyz.block.microfilm.scanning.ImageGroupFixtures.RESOURCES_DIRECTORY
+import xyz.block.microfilm.scanning.ImageGroupFixtures.RESOURCES_PNG
+import xyz.block.microfilm.scanning.ImageGroupFixtures.RESOURCES_WEBP
+import xyz.block.microfilm.scanning.ImageGroupFixtures.WEBP_CONTENT
+
+class RealDecompressorTest {
+  private val fileSystem = FakeFileSystem()
+
+  private val decompressor =
+    RealDecompressor(
+      fileSystem = fileSystem,
+      resourcesDirectory = RESOURCES_DIRECTORY,
+      microfilmDirectory = MICROFILM_DIRECTORY,
+    )
+
+  @AfterEach
+  fun tearDown() {
+    fileSystem.checkNoOpenFiles()
+  }
+
+  @Test
+  fun `decompress ignores lone resources png`() {
+    fileSystem.createDirectories(dir = RESOURCES_PNG.parent!!)
+    fileSystem.write(file = RESOURCES_PNG) { write(byteString = PNG_CONTENT.encodeUtf8()) }
+
+    decompressor.decompress(imageGroup = EMPTY_IMAGE_GROUP.copy(resourcesPng = RESOURCES_PNG))
+
+    assertThat(fileSystem.exists(RESOURCES_PNG)).isTrue()
+    assertThat(fileSystem.exists(RESOURCES_WEBP)).isFalse()
+    assertThat(fileSystem.exists(MICROFILM_PNG)).isFalse()
+  }
+
+  @Test
+  fun `decompress ignores lone resources webp`() {
+    fileSystem.createDirectories(dir = RESOURCES_WEBP.parent!!)
+    fileSystem.write(file = RESOURCES_WEBP) { write(byteString = WEBP_CONTENT.encodeUtf8()) }
+
+    decompressor.decompress(imageGroup = EMPTY_IMAGE_GROUP.copy(resourcesWebp = RESOURCES_WEBP))
+
+    assertThat(fileSystem.exists(RESOURCES_PNG)).isFalse()
+    assertThat(fileSystem.exists(RESOURCES_WEBP)).isTrue()
+    assertThat(fileSystem.exists(MICROFILM_PNG)).isFalse()
+  }
+
+  @Test
+  fun `decompress restores microfilm png`() {
+    fileSystem.createDirectories(dir = MICROFILM_PNG.parent!!)
+    fileSystem.write(file = MICROFILM_PNG) { write(byteString = PNG_CONTENT.encodeUtf8()) }
+
+    decompressor.decompress(imageGroup = EMPTY_IMAGE_GROUP.copy(microfilmPng = MICROFILM_PNG))
+
+    assertThat(fileSystem.exists(RESOURCES_PNG)).isTrue()
+    assertThat(fileSystem.exists(RESOURCES_WEBP)).isFalse()
+    assertThat(fileSystem.exists(MICROFILM_PNG)).isFalse()
+  }
+
+  @Test
+  fun `decompress restores microfilm png and removes resources webp`() {
+    fileSystem.createDirectories(dir = RESOURCES_WEBP.parent!!)
+    fileSystem.createDirectories(dir = MICROFILM_PNG.parent!!)
+    fileSystem.write(file = RESOURCES_WEBP) { write(byteString = WEBP_CONTENT.encodeUtf8()) }
+    fileSystem.write(file = MICROFILM_PNG) { write(byteString = PNG_CONTENT.encodeUtf8()) }
+
+    decompressor.decompress(imageGroup = LOSSY_IMAGE_GROUP)
+
+    assertThat(fileSystem.exists(RESOURCES_PNG)).isTrue()
+    assertThat(fileSystem.exists(RESOURCES_WEBP)).isFalse()
+    assertThat(fileSystem.exists(MICROFILM_PNG)).isFalse()
+  }
+
+  @Test
+  fun `decompress ignores lone manifest entry microfilm png`() {
+    decompressor.decompress(
+      imageGroup = EMPTY_IMAGE_GROUP.copy(microfilmManifestEntry = LOSSY_MANIFEST_ENTRY)
+    )
+
+    assertThat(fileSystem.exists(RESOURCES_PNG)).isFalse()
+    assertThat(fileSystem.exists(RESOURCES_WEBP)).isFalse()
+    assertThat(fileSystem.exists(MICROFILM_PNG)).isFalse()
+  }
+}


### PR DESCRIPTION
At the moment, it's a little tedious to delete an image managed by Microfilm. If you delete the WebP, Microfilm will just restore it the next time you run compress. So you have to do 3 things:
1. Delete the WebP in the `res` directory
2. Delete the PNG in the `microfilm` directory
3. Run `compressMicrofilm` to update the manifest

In particular I think step 2 is a little clunky because it requires people to poke into the internals of the `microfilm` directory. That's not too terrible — the layout of the directory is straightforward and it's not like the contents are supposed to be secret. But something about it feels a little odd.

One solution would be to offer something like a `deleteMicrofilm` task, where you supply an image path and the plugin takes care of deleting the compressed image, the uncompressed image, the manifest entry, etc. I can see this being useful, but it feels a bit off. It doesn't just undo the output of `compressMicrofilm`, it goes one step further and performs a basic file operation that you would normally just do in your IDE or on the command line. What if you don't actually want to delete the image, you just want to move it to another directory? Or you want to rename it?

Another solution would be to offer a `decompressMicrofilm` task that is symmetric with `compressMicrofilm`. It would remove the compressed WebP image, restore the original uncompressed PNG, and remove the manifest entry. Then the user can delete the file, move it, rename it, whatever. It composes nicely with any regular file operation that you want to perform.

This PR proposes a first step toward that `decompressMicrofilm` approach. At the moment, you can't run it for a specific file, so you would have to do decompress all images, delete/move/rename the image you're interested in, and recompress the rest. The next step would be to add a version that runs for individual images (or images that match a glob pattern). I think that would be useful for our existing compress and verify tasks too, so I want to think about how to support it for all three holistically.