### PR TITLE
Add a command line option to compress a subset of images matching a glob pattern

### DIFF
--- a/plugin/src/main/kotlin/xyz/block/microfilm/Globs.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/Globs.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2026 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package xyz.block.microfilm
+
+import java.nio.file.FileSystems
+import java.nio.file.Path
+
+/** Returns true if this path matches the given glob pattern. */
+internal fun String.matchesGlob(pattern: String): Boolean =
+  FileSystems.getDefault().getPathMatcher("glob:$pattern").matches(Path.of(this))
+
+/** Returns true if this path matches any of the given glob patterns. */
+internal fun String.matchesGlobs(patterns: List<String>): Boolean = patterns.any { pattern ->
+  matchesGlob(pattern = pattern)
+}
+
+/** Returns true if this path matches the given glob pattern. */
+internal fun okio.Path.matchesGlob(pattern: String): Boolean =
+  toString().matchesGlob(pattern = pattern)
+
+/** Returns true if this path matches the given glob pattern. */
+internal fun okio.Path.matchesGlobs(patterns: List<String>): Boolean = patterns.any { pattern ->
+  matchesGlob(pattern = pattern)
+}
+
+/** Returns true if this path matches the given glob pattern. */
+internal fun List<okio.Path>.matchesGlobs(patterns: List<String>): Boolean = any { path ->
+  path.matchesGlobs(patterns = patterns)
+}

--- a/plugin/src/main/kotlin/xyz/block/microfilm/ImageRule.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/ImageRule.kt
@@ -16,14 +16,12 @@
 package xyz.block.microfilm
 
 import java.io.Serializable
-import java.nio.file.FileSystems
-import java.nio.file.Path
 
 internal data class ImageRule(val pattern: String, val imageSettings: ImageSettings) : Serializable
 
 /** Returns true if the [ImageRule] matches the given image. */
 internal fun ImageRule.matches(imagePath: String): Boolean =
-  FileSystems.getDefault().getPathMatcher("glob:$pattern").matches(Path.of(imagePath))
+  imagePath.matchesGlob(pattern = pattern)
 
 /** Returns the last [ImageRule] that matches the given image, or null if none match. */
 internal fun List<ImageRule>.resolve(imagePath: String): ImageRule? = lastOrNull { imageRule ->

--- a/plugin/src/main/kotlin/xyz/block/microfilm/compression/CompressTask.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/compression/CompressTask.kt
@@ -30,6 +30,7 @@ import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity.RELATIVE
 import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.options.Option
 import org.gradle.process.ExecOperations
 import org.gradle.work.DisableCachingByDefault
 import xyz.block.microfilm.ImageRule
@@ -46,6 +47,14 @@ constructor(private val execOperations: ExecOperations) : DefaultTask() {
   @get:InputFiles
   @get:PathSensitive(RELATIVE)
   abstract val cwebpDirectory: ConfigurableFileCollection
+
+  @get:Internal
+  @get:Option(
+    option = "images",
+    description =
+      "Compress the images matching these glob patterns, relative to the res directory.",
+  )
+  abstract val imagePatterns: ListProperty<String>
 
   @get:Internal abstract val imageRules: ListProperty<ImageRule>
 
@@ -97,6 +106,7 @@ constructor(private val execOperations: ExecOperations) : DefaultTask() {
     val results =
       compressor.compress(
         scanner = scanner,
+        imagePatterns = imagePatterns.get().ifEmpty { listOf("**") },
         imageRules = imageRules.get(),
         resourcesDirectory = resourcesDirectoryPath,
         microfilmDirectory = microfilmDirectoryPath,

--- a/plugin/src/main/kotlin/xyz/block/microfilm/compression/Compressor.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/compression/Compressor.kt
@@ -23,6 +23,8 @@ import xyz.block.microfilm.ImageSettings.Exclude
 import xyz.block.microfilm.ImageSettings.Unspecified
 import xyz.block.microfilm.Manifest
 import xyz.block.microfilm.compression.Compressor.Result
+import xyz.block.microfilm.compression.Compressor.Result.Success
+import xyz.block.microfilm.matchesGlobs
 import xyz.block.microfilm.resolve
 import xyz.block.microfilm.scanning.ImageGroup
 import xyz.block.microfilm.scanning.Scanner
@@ -52,6 +54,7 @@ internal interface Compressor<T : ImageSettings> {
 /** Scans for images, pairs them with rules from the Gradle configuration, and compresses them. */
 internal fun Compressor<ImageSettings>.compress(
   scanner: Scanner,
+  imagePatterns: List<String>,
   imageRules: List<ImageRule>,
   resourcesDirectory: Path,
   microfilmDirectory: Path,
@@ -71,6 +74,10 @@ internal fun Compressor<ImageSettings>.compress(
 
         else -> null
       } ?: Unspecified
-    compress(imageGroup = imageGroup, imageSettings = imageSettings)
+    if (listOfNotNull(pngPath, webpPath).matchesGlobs(patterns = imagePatterns)) {
+      compress(imageGroup = imageGroup, imageSettings = imageSettings)
+    } else {
+      Success(microfilmManifestEntry = imageGroup.microfilmManifestEntry)
+    }
   }
 }

--- a/plugin/src/test/kotlin/xyz/block/microfilm/GlobsTest.kt
+++ b/plugin/src/test/kotlin/xyz/block/microfilm/GlobsTest.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2026 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package xyz.block.microfilm
+
+import assertk.assertThat
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
+import okio.Path.Companion.toPath
+import org.junit.jupiter.api.Test
+
+class GlobsTest {
+  @Test
+  fun `single wildcard stays within one directory`() {
+    assertThat(PNG.matchesGlob(pattern = "*/photo.png")).isTrue()
+    assertThat(NESTED_PNG.matchesGlob(pattern = "*/photo.png")).isFalse()
+  }
+
+  @Test
+  fun `double wildcard crosses directories`() {
+    assertThat(PNG.matchesGlob(pattern = "**/photo.png")).isTrue()
+    assertThat(NESTED_PNG.matchesGlob(pattern = "**/photo.png")).isTrue()
+  }
+
+  @Test
+  fun `double wildcard requires a directory`() {
+    assertThat("photo.png".matchesGlob(pattern = "**/photo.png")).isFalse()
+    assertThat("photo.png".matchesGlob(pattern = "**")).isTrue()
+  }
+
+  @Test
+  fun `alternation matches either extension`() {
+    assertThat(PNG.matchesGlob(pattern = "**/photo.{png,webp}")).isTrue()
+    assertThat(WEBP.matchesGlob(pattern = "**/photo.{png,webp}")).isTrue()
+    assertThat(OTHER_PNG.matchesGlob(pattern = "**/photo.{png,webp}")).isFalse()
+  }
+
+  @Test
+  fun `path matches the same patterns as its string`() {
+    assertThat(PNG.toPath().matchesGlob(pattern = "**/photo.png")).isTrue()
+    assertThat(OTHER_PNG.toPath().matchesGlob(pattern = "**/photo.png")).isFalse()
+  }
+
+  private companion object {
+    private const val PNG = "drawable-mdpi/photo.png"
+    private const val WEBP = "drawable-mdpi/photo.webp"
+    private const val NESTED_PNG = "drawable-mdpi/nested/photo.png"
+    private const val OTHER_PNG = "drawable-mdpi/other.png"
+  }
+}

--- a/plugin/src/test/kotlin/xyz/block/microfilm/compression/CompressorTest.kt
+++ b/plugin/src/test/kotlin/xyz/block/microfilm/compression/CompressorTest.kt
@@ -17,6 +17,7 @@ package xyz.block.microfilm.compression
 
 import assertk.assertThat
 import assertk.assertions.containsExactly
+import assertk.assertions.isEmpty
 import org.junit.jupiter.api.Test
 import xyz.block.microfilm.ImageRule
 import xyz.block.microfilm.ImageSettings
@@ -26,9 +27,12 @@ import xyz.block.microfilm.scanning.FakeScanner
 import xyz.block.microfilm.scanning.ImageGroup
 import xyz.block.microfilm.scanning.ImageGroupFixtures.EMPTY_IMAGE_GROUP
 import xyz.block.microfilm.scanning.ImageGroupFixtures.LOSSY_COMPRESS
+import xyz.block.microfilm.scanning.ImageGroupFixtures.LOSSY_IMAGE_GROUP
 import xyz.block.microfilm.scanning.ImageGroupFixtures.LOSSY_MANIFEST_ENTRY
 import xyz.block.microfilm.scanning.ImageGroupFixtures.MICROFILM_DIRECTORY
 import xyz.block.microfilm.scanning.ImageGroupFixtures.MICROFILM_PNG
+import xyz.block.microfilm.scanning.ImageGroupFixtures.RELATIVE_PNG
+import xyz.block.microfilm.scanning.ImageGroupFixtures.RELATIVE_WEBP
 import xyz.block.microfilm.scanning.ImageGroupFixtures.RESOURCES_DIRECTORY
 import xyz.block.microfilm.scanning.ImageGroupFixtures.RESOURCES_PNG
 import xyz.block.microfilm.scanning.ImageGroupFixtures.RESOURCES_WEBP
@@ -126,16 +130,49 @@ class CompressorTest {
     )
   }
 
+  @Test
+  fun `compress respects image patterns`() {
+    verifyCompress(
+      imageGroup = LOSSY_IMAGE_GROUP,
+      imagePattern = RELATIVE_PNG,
+      imageSettings = LOSSY_COMPRESS,
+      expected = LOSSY_COMPRESS,
+    )
+
+    verifyCompress(
+      imageGroup = LOSSY_IMAGE_GROUP,
+      imagePattern = "other.png",
+      imageSettings = LOSSY_COMPRESS,
+      expected = null,
+    )
+
+    verifyCompress(
+      imageGroup = LOSSY_IMAGE_GROUP,
+      imagePattern = RELATIVE_WEBP,
+      imageSettings = LOSSY_COMPRESS,
+      expected = LOSSY_COMPRESS,
+    )
+
+    verifyCompress(
+      imageGroup = LOSSY_IMAGE_GROUP,
+      imagePattern = "other.webp",
+      imageSettings = LOSSY_COMPRESS,
+      expected = null,
+    )
+  }
+
   private fun verifyCompress(
     imageGroup: ImageGroup,
+    imagePattern: String = "**",
     imageSettings: ImageSettings?,
-    expected: ImageSettings,
+    expected: ImageSettings?,
   ) {
     val compressor = FakeCompressor<ImageSettings>()
     val scanner = FakeScanner().apply { scanResponses.add(listOf(imageGroup)) }
 
     compressor.compress(
       scanner = scanner,
+      imagePatterns = listOf(imagePattern),
       imageRules =
         if (imageSettings != null) {
           listOf(ImageRule(pattern = "**", imageSettings = imageSettings))
@@ -146,6 +183,10 @@ class CompressorTest {
       microfilmDirectory = MICROFILM_DIRECTORY,
     )
 
-    assertThat(compressor.compressRequests).containsExactly(imageGroup to expected)
+    if (expected == null) {
+      assertThat(compressor.compressRequests).isEmpty()
+    } else {
+      assertThat(compressor.compressRequests).containsExactly(imageGroup to expected)
+    }
   }
 }


### PR DESCRIPTION
## Context
Right now you can't filter any of the Microfilm tasks. So if you want to compress/verify a specific image, you have to compress/verify the whole module. I think it would be helpful to be able to run tasks on a subset of images, similar to how you can filter tests with the `--tests` option.

## This PR
Adds a `--images` option to the compress task. The option accepts a glob pattern that you can use to target specific subsets of images for compression. You can also repeat the option if you want to supply multiple glob patterns. It looks like this:
```
./gradlew compressMicrofilmMain --images="**/my_image.png"
```