### PR TITLE
Add a command line option to verify a subset of images matching a glob pattern

### DIFF
--- a/plugin/src/main/kotlin/xyz/block/microfilm/verification/Verifier.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/verification/Verifier.kt
@@ -21,10 +21,12 @@ import xyz.block.microfilm.ImageRule
 import xyz.block.microfilm.ImageSettings
 import xyz.block.microfilm.ImageSettings.Exclude
 import xyz.block.microfilm.ImageSettings.Unspecified
+import xyz.block.microfilm.matchesGlobs
 import xyz.block.microfilm.resolve
 import xyz.block.microfilm.scanning.ImageGroup
 import xyz.block.microfilm.scanning.Scanner
 import xyz.block.microfilm.verification.Verifier.Result
+import xyz.block.microfilm.verification.Verifier.Result.Success
 
 /**
  * A verifier that checks images against the image settings declared in the Gradle configuration.
@@ -54,6 +56,7 @@ internal interface Verifier<T : ImageSettings> {
  */
 internal fun Verifier<ImageSettings>.verify(
   scanner: Scanner,
+  imagePatterns: List<String>,
   imageRules: List<ImageRule>,
   resourcesDirectory: Path,
   microfilmDirectory: Path,
@@ -73,6 +76,10 @@ internal fun Verifier<ImageSettings>.verify(
 
         else -> null
       } ?: Unspecified
-    verify(imageGroup = imageGroup, imageSettings = imageSettings)
+    if (listOfNotNull(pngPath, webpPath).matchesGlobs(patterns = imagePatterns)) {
+      verify(imageGroup = imageGroup, imageSettings = imageSettings)
+    } else {
+      Success(key = imageGroup.key)
+    }
   }
 }

--- a/plugin/src/main/kotlin/xyz/block/microfilm/verification/VerifyTask.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/verification/VerifyTask.kt
@@ -28,6 +28,7 @@ import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity.RELATIVE
 import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.options.Option
 import org.gradle.process.ExecOperations
 import org.gradle.work.DisableCachingByDefault
 import xyz.block.microfilm.ImageRule
@@ -41,6 +42,13 @@ internal abstract class VerifyTask @Inject constructor(private val execOperation
   @get:InputFiles
   @get:PathSensitive(RELATIVE)
   abstract val cwebpDirectory: ConfigurableFileCollection
+
+  @get:Internal
+  @get:Option(
+    option = "images",
+    description = "Verify the images matching these glob patterns, relative to the res directory.",
+  )
+  abstract val imagePatterns: ListProperty<String>
 
   @get:Internal abstract val imageRules: ListProperty<ImageRule>
 
@@ -71,6 +79,7 @@ internal abstract class VerifyTask @Inject constructor(private val execOperation
               resourcesDirectory = resourcesDirectoryPath,
               microfilmDirectory = microfilmDirectoryPath,
             ),
+          imagePatterns = imagePatterns.get().ifEmpty { listOf("**") },
           imageRules = imageRules.get(),
           resourcesDirectory = resourcesDirectoryPath,
           microfilmDirectory = microfilmDirectoryPath,

--- a/plugin/src/test/kotlin/xyz/block/microfilm/verification/VerifierTest.kt
+++ b/plugin/src/test/kotlin/xyz/block/microfilm/verification/VerifierTest.kt
@@ -1,0 +1,192 @@
+/*
+ * Copyright (C) 2026 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package xyz.block.microfilm.verification
+
+import assertk.assertThat
+import assertk.assertions.containsExactly
+import assertk.assertions.isEmpty
+import org.junit.jupiter.api.Test
+import xyz.block.microfilm.ImageRule
+import xyz.block.microfilm.ImageSettings
+import xyz.block.microfilm.ImageSettings.Exclude
+import xyz.block.microfilm.ImageSettings.Unspecified
+import xyz.block.microfilm.scanning.FakeScanner
+import xyz.block.microfilm.scanning.ImageGroup
+import xyz.block.microfilm.scanning.ImageGroupFixtures.EMPTY_IMAGE_GROUP
+import xyz.block.microfilm.scanning.ImageGroupFixtures.LOSSY_COMPRESS
+import xyz.block.microfilm.scanning.ImageGroupFixtures.LOSSY_IMAGE_GROUP
+import xyz.block.microfilm.scanning.ImageGroupFixtures.LOSSY_MANIFEST_ENTRY
+import xyz.block.microfilm.scanning.ImageGroupFixtures.MICROFILM_DIRECTORY
+import xyz.block.microfilm.scanning.ImageGroupFixtures.MICROFILM_PNG
+import xyz.block.microfilm.scanning.ImageGroupFixtures.RELATIVE_PNG
+import xyz.block.microfilm.scanning.ImageGroupFixtures.RELATIVE_WEBP
+import xyz.block.microfilm.scanning.ImageGroupFixtures.RESOURCES_DIRECTORY
+import xyz.block.microfilm.scanning.ImageGroupFixtures.RESOURCES_PNG
+import xyz.block.microfilm.scanning.ImageGroupFixtures.RESOURCES_WEBP
+
+class VerifierTest {
+  @Test
+  fun `verify matches resource png`() {
+    val imageGroup = EMPTY_IMAGE_GROUP.copy(resourcesPng = RESOURCES_PNG)
+
+    assertVerify(
+      imageGroup = imageGroup,
+      imageSettings = LOSSY_COMPRESS,
+      expected = LOSSY_COMPRESS,
+    )
+
+    assertVerify(
+      imageGroup = imageGroup,
+      imageSettings = Exclude,
+      expected = Exclude,
+    )
+
+    assertVerify(
+      imageGroup = imageGroup,
+      imageSettings = null,
+      expected = Unspecified,
+    )
+  }
+
+  @Test
+  fun `verify matches resource webp`() {
+    val imageGroup = EMPTY_IMAGE_GROUP.copy(resourcesWebp = RESOURCES_WEBP)
+
+    assertVerify(
+      imageGroup = imageGroup,
+      imageSettings = LOSSY_COMPRESS,
+      expected = Unspecified,
+    )
+
+    assertVerify(
+      imageGroup = imageGroup,
+      imageSettings = Exclude,
+      expected = Exclude,
+    )
+
+    assertVerify(
+      imageGroup = imageGroup,
+      imageSettings = null,
+      expected = Unspecified,
+    )
+  }
+
+  @Test
+  fun `verify matches microfilm png`() {
+    val imageGroup = EMPTY_IMAGE_GROUP.copy(microfilmPng = MICROFILM_PNG)
+
+    assertVerify(
+      imageGroup = imageGroup,
+      imageSettings = LOSSY_COMPRESS,
+      expected = LOSSY_COMPRESS,
+    )
+
+    assertVerify(
+      imageGroup = imageGroup,
+      imageSettings = Exclude,
+      expected = Exclude,
+    )
+
+    assertVerify(
+      imageGroup = imageGroup,
+      imageSettings = null,
+      expected = Unspecified,
+    )
+  }
+
+  @Test
+  fun `verify matches microfilm manifest entry`() {
+    val imageGroup = EMPTY_IMAGE_GROUP.copy(microfilmManifestEntry = LOSSY_MANIFEST_ENTRY)
+
+    assertVerify(
+      imageGroup = imageGroup,
+      imageSettings = LOSSY_COMPRESS,
+      expected = LOSSY_COMPRESS,
+    )
+
+    assertVerify(
+      imageGroup = imageGroup,
+      imageSettings = Exclude,
+      expected = Exclude,
+    )
+
+    assertVerify(
+      imageGroup = imageGroup,
+      imageSettings = null,
+      expected = Unspecified,
+    )
+  }
+
+  @Test
+  fun `verify respects image patterns`() {
+    assertVerify(
+      imageGroup = LOSSY_IMAGE_GROUP,
+      imagePattern = RELATIVE_PNG,
+      imageSettings = LOSSY_COMPRESS,
+      expected = LOSSY_COMPRESS,
+    )
+
+    assertVerify(
+      imageGroup = LOSSY_IMAGE_GROUP,
+      imagePattern = "other.png",
+      imageSettings = LOSSY_COMPRESS,
+      expected = null,
+    )
+
+    assertVerify(
+      imageGroup = LOSSY_IMAGE_GROUP,
+      imagePattern = RELATIVE_WEBP,
+      imageSettings = LOSSY_COMPRESS,
+      expected = LOSSY_COMPRESS,
+    )
+
+    assertVerify(
+      imageGroup = LOSSY_IMAGE_GROUP,
+      imagePattern = "other.webp",
+      imageSettings = LOSSY_COMPRESS,
+      expected = null,
+    )
+  }
+
+  private fun assertVerify(
+    imageGroup: ImageGroup,
+    imagePattern: String = "**",
+    imageSettings: ImageSettings?,
+    expected: ImageSettings?,
+  ) {
+    val verifier = FakeVerifier<ImageSettings>()
+    val scanner = FakeScanner().apply { scanResponses.add(listOf(imageGroup)) }
+
+    verifier.verify(
+      scanner = scanner,
+      imagePatterns = listOf(imagePattern),
+      imageRules =
+        if (imageSettings != null) {
+          listOf(ImageRule(pattern = "**", imageSettings = imageSettings))
+        } else {
+          emptyList()
+        },
+      resourcesDirectory = RESOURCES_DIRECTORY,
+      microfilmDirectory = MICROFILM_DIRECTORY,
+    )
+
+    if (expected == null) {
+      assertThat(verifier.verifyRequests).isEmpty()
+    } else {
+      assertThat(verifier.verifyRequests).containsExactly(imageGroup to expected)
+    }
+  }
+}


### PR DESCRIPTION
## Context
Right now you can't filter any of the Microfilm tasks. So if you want to compress/verify a specific image, you have to compress/verify the whole module. I think it would be helpful to be able to run tasks on a subset of images, similar to how you can filter tests with the `--tests` option.

## This PR
Adds a `--images` option to the verify task. The option accepts a glob pattern that you can use to target specific subsets of images for verification. You can also repeat the option if you want to supply multiple glob patterns. It looks like this:
```
./gradlew verifyMicrofilmMain --images="**/my_image.png"
```