### PR TITLE
Make a best effort to support Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,6 @@ The verification task ensures that the images and the compression settings in th
 
 ## Modules
 
-* [cwebp](cwebp): The cwebp executable, packaged into platform-specific dependencies (currently Mac and Linux).
+* [cwebp](cwebp): The cwebp executable, packaged into platform-specific dependencies (currently Mac, Linux, and Windows).
 * [plugin](plugin): The Gradle plugin, with logic to compress and verify resource images.
 * [sample](sample): A sample Android project that demonstrates usage of the plugin.

--- a/cwebp/build.gradle.kts
+++ b/cwebp/build.gradle.kts
@@ -1,6 +1,5 @@
 import java.net.URI
 import java.security.MessageDigest
-import javax.inject.Inject
 import org.gradle.nativeplatform.MachineArchitecture
 import org.gradle.nativeplatform.MachineArchitecture.ARCHITECTURE_ATTRIBUTE
 import org.gradle.nativeplatform.MachineArchitecture.ARM64
@@ -9,7 +8,7 @@ import org.gradle.nativeplatform.OperatingSystemFamily
 import org.gradle.nativeplatform.OperatingSystemFamily.LINUX
 import org.gradle.nativeplatform.OperatingSystemFamily.MACOS
 import org.gradle.nativeplatform.OperatingSystemFamily.OPERATING_SYSTEM_ATTRIBUTE
-import org.gradle.process.ExecOperations
+import org.gradle.nativeplatform.OperatingSystemFamily.WINDOWS
 
 plugins {
   base
@@ -49,16 +48,29 @@ enum class CwebpPlatform(
     archivePlatform = "linux-x86-64",
     sha256 = "1c5ffab71efecefa0e3c23516c3a3a1dccb45cc310ae1095c6f14ae268e38067",
   ),
+  WindowsX86_64(
+    osFamily = WINDOWS,
+    architecture = X86_64,
+    archivePlatform = "windows-x64",
+    sha256 = "48886f506b21f62e4661f0f4cbfca19800897c385128e8902542d29a950c93f1",
+  ),
 }
 
 val CwebpPlatform.archiveName
-  get() = "libwebp-${libs.versions.cwebp.get()}-$archivePlatform.tar.gz"
+  get() =
+    "libwebp-${libs.versions.cwebp.get()}-$archivePlatform.${if (isWindows) "zip" else "tar.gz"}"
+
+val CwebpPlatform.binaryName
+  get() = if (isWindows) "cwebp.exe" else "cwebp"
 
 val CwebpPlatform.binaryPath
-  get() = "libwebp-${libs.versions.cwebp.get()}-$archivePlatform/bin/cwebp"
+  get() = "libwebp-${libs.versions.cwebp.get()}-$archivePlatform/bin/$binaryName"
 
 val CwebpPlatform.downloadUrl
   get() = "https://storage.googleapis.com/downloads.webmproject.org/releases/webp/$archiveName"
+
+val CwebpPlatform.isWindows
+  get() = osFamily == WINDOWS
 
 fun File.sha256Hex(): String {
   val digest = MessageDigest.getInstance("SHA-256")
@@ -107,11 +119,6 @@ fun TaskContainer.registerDownloadTask(platform: CwebpPlatform): TaskProvider<Ta
     }
   }
 
-// ExecOperations must be injected via Gradle's service injection in Gradle 9+
-abstract class Exec @Inject constructor(val ops: ExecOperations)
-
-val exec = objects.newInstance<Exec>()
-
 fun TaskContainer.registerExtractTask(
   platform: CwebpPlatform,
   download: TaskProvider<Task>,
@@ -124,25 +131,17 @@ fun TaskContainer.registerExtractTask(
     inputs.file(archive)
 
     // Register the binary file as an output
-    val binary = layout.buildDirectory.file("binaries/$platform/cwebp")
+    val binary = layout.buildDirectory.file("binaries/$platform/${platform.binaryName}")
     outputs.file(binary)
 
     doLast {
       // Extract the binary from the archive
-      val archiveFile = archive.get()
-      val binaryFile = binary.get().asFile.apply { parentFile.mkdirs() }
-      exec.ops.exec {
-        commandLine(
-          "tar",
-          "xzf",
-          archiveFile.absolutePath,
-          "-C",
-          binaryFile.parentFile.absolutePath,
-          "--strip-components",
-          platform.binaryPath.count { it == '/' }.toString(),
-          platform.binaryPath,
-        )
-      }
+      val binaryFile = binary.get().asFile
+      val archiveTree = if (platform.isWindows) zipTree(archive) else tarTree(archive)
+      archiveTree
+        .matching { include(platform.binaryPath) }
+        .singleFile
+        .copyTo(binaryFile, overwrite = true)
 
       // Set the binary as executable
       binaryFile.setExecutable(true)

--- a/plugin/src/main/kotlin/xyz/block/microfilm/MicrofilmPlugin.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/MicrofilmPlugin.kt
@@ -34,6 +34,7 @@ import org.gradle.nativeplatform.OperatingSystemFamily
 import org.gradle.nativeplatform.OperatingSystemFamily.LINUX
 import org.gradle.nativeplatform.OperatingSystemFamily.MACOS
 import org.gradle.nativeplatform.OperatingSystemFamily.OPERATING_SYSTEM_ATTRIBUTE
+import org.gradle.nativeplatform.OperatingSystemFamily.WINDOWS
 import xyz.block.microfilm.compression.CompressTask
 import xyz.block.microfilm.cwebp.ExtractCwebpBinary
 import xyz.block.microfilm.verification.VerifyTask
@@ -199,6 +200,7 @@ private fun currentOperatingSystemFamily(): String {
   return when {
     operatingSystem.contains("mac") -> MACOS
     operatingSystem.contains("linux") -> LINUX
+    operatingSystem.contains("windows") -> WINDOWS
     else -> error("Unsupported operating system: $operatingSystem")
   }
 }

--- a/plugin/src/main/kotlin/xyz/block/microfilm/Paths.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/Paths.kt
@@ -22,6 +22,10 @@ import okio.Path.Companion.toPath
 /** Matches Android drawable resource directories like `drawable` and `drawable-hdpi`. */
 private val DRAWABLE_DIRECTORY_PATTERN = Regex(pattern = "^drawable(-.*)?$")
 
+/** Returns the string form of this path with `/` separators, regardless of the platform. */
+internal val Path.invariantSeparatorsPath
+  get() = segments.joinToString(separator = "/")
+
 /** True if this is a file in a drawable directory. */
 internal val Path.isInDrawableDirectory
   get() = parent?.name?.matches(regex = DRAWABLE_DIRECTORY_PATTERN) == true

--- a/plugin/src/main/kotlin/xyz/block/microfilm/compression/CompressCompressor.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/compression/CompressCompressor.kt
@@ -22,6 +22,7 @@ import xyz.block.microfilm.Manifest.Entry
 import xyz.block.microfilm.compression.Compressor.Result
 import xyz.block.microfilm.compression.Compressor.Result.Success
 import xyz.block.microfilm.cwebp.Cwebp
+import xyz.block.microfilm.invariantSeparatorsPath
 import xyz.block.microfilm.replaceExtension
 import xyz.block.microfilm.scanning.ImageGroup
 import xyz.block.microfilm.sha256
@@ -83,9 +84,10 @@ internal class CompressCompressor(
     return Success(
       microfilmManifestEntry =
         Entry(
-          sourcePath = microfilmPng.relativeTo(other = microfilmDirectory).toString(),
+          sourcePath = microfilmPng.relativeTo(other = microfilmDirectory).invariantSeparatorsPath,
           sourceSha256 = fileSystem.sha256(file = microfilmPng),
-          compressedPath = resourcesWebp.relativeTo(other = resourcesDirectory).toString(),
+          compressedPath =
+            resourcesWebp.relativeTo(other = resourcesDirectory).invariantSeparatorsPath,
           compressedSha256 = fileSystem.sha256(file = resourcesWebp),
           compressor = imageSettings.toCompressor(cwebpVersion = cwebpVersion),
         )

--- a/plugin/src/main/kotlin/xyz/block/microfilm/cwebp/ExtractCwebpBinary.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/cwebp/ExtractCwebpBinary.kt
@@ -35,11 +35,13 @@ internal abstract class ExtractCwebpBinary : TransformAction<None> {
 
   override fun transform(outputs: TransformOutputs) {
     val inputJarFile = inputJar.get().asFile
-    val outputExecutableFile = outputs.dir(inputJarFile.nameWithoutExtension).resolve("cwebp")
     ZipInputStream(inputJarFile.inputStream().buffered()).use { zip ->
       while (true) {
         val entry = zip.nextEntry ?: break
-        if (!entry.isDirectory && entry.name.substringAfterLast('/') == "cwebp") {
+        val entryName = entry.name.substringAfterLast('/')
+        if (!entry.isDirectory && (entryName == "cwebp" || entryName == "cwebp.exe")) {
+          val outputExecutableFile =
+            outputs.dir(inputJarFile.nameWithoutExtension).resolve(entryName)
           outputExecutableFile.outputStream().buffered().use { zip.copyTo(it) }
           outputExecutableFile.setExecutable(true)
           break

--- a/plugin/src/main/kotlin/xyz/block/microfilm/cwebp/RealCwebp.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/cwebp/RealCwebp.kt
@@ -16,7 +16,6 @@
 package xyz.block.microfilm.cwebp
 
 import java.io.ByteArrayOutputStream
-import kotlin.io.resolve
 import okio.Path
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.process.ExecOperations
@@ -27,7 +26,13 @@ internal class RealCwebp(
   private val execOperations: ExecOperations,
   private val directory: ConfigurableFileCollection,
 ) : Cwebp {
-  private val executable by lazy { directory.singleFile.resolve("cwebp") }
+  // The binary is named `cwebp` on Mac and Linux and `cwebp.exe` on Windows
+  private val executable by lazy {
+    directory.singleFile.listFiles().orEmpty().single { file ->
+      file.nameWithoutExtension == "cwebp"
+    }
+  }
+
   private val _version by lazy {
     val output = ByteArrayOutputStream()
     execOperations.exec { action ->

--- a/plugin/src/test/kotlin/xyz/block/microfilm/PathsTest.kt
+++ b/plugin/src/test/kotlin/xyz/block/microfilm/PathsTest.kt
@@ -27,6 +27,18 @@ import xyz.block.microfilm.scanning.ImageGroupFixtures.RESOURCES_WEBP
 
 class PathsTest {
   @Test
+  fun `invariantSeparatorsPath retains separators in unix path`() {
+    assertThat("drawable-hdpi/image.png".toPath().invariantSeparatorsPath)
+      .isEqualTo("drawable-hdpi/image.png")
+  }
+
+  @Test
+  fun `invariantSeparatorsPath replaces separators in windows path`() {
+    assertThat("drawable-hdpi\\image.png".toPath().invariantSeparatorsPath)
+      .isEqualTo("drawable-hdpi/image.png")
+  }
+
+  @Test
   fun `isInDrawableDirectory is true for file in unqualified drawable directory`() {
     assertThat("src/main/res/drawable/image.png".toPath().isInDrawableDirectory).isTrue()
   }


### PR DESCRIPTION
We currently support Linux and Mac, and now I'm making a best effort to support Windows as well (though I don't have easy access to a Windows machine to properly check). Mainly this means:
- Bundling a `cwebp` executable built for Windows
- Making sure that we're using consistent paths across platforms (i.e. using `/` separators instead of `\` even on Windows)