### PR TITLE
Fix a Gradle warning about project depedendencies

### DIFF
--- a/plugin/src/main/kotlin/xyz/block/microfilm/MicrofilmPlugin.kt
+++ b/plugin/src/main/kotlin/xyz/block/microfilm/MicrofilmPlugin.kt
@@ -70,7 +70,7 @@ public class MicrofilmPlugin : Plugin<Project> {
     dependencies.add(
       cwebpConfiguration.name,
       if (providers.gradleProperty("xyz.block.microfilm.internal").getOrElse("false").toBoolean()) {
-        project(":cwebp")
+        dependencyFactory.createProjectDependency(":cwebp")
       } else {
         "xyz.block.microfilm:microfilm-cwebp:${BuildConfig.microfilmVersion}"
       },


### PR DESCRIPTION
Gradle is logging a deprecation warning related to the `:cwebp` project dependency that we add for local development:
```
Using a Project object as a dependency notation has been deprecated. This will fail with an error in Gradle 10.
```

I'm migrating to what I think is the new API.